### PR TITLE
refactor(query): remove unimplemented public API stubs and stale TODOs

### DIFF
--- a/src/surinort_ast/query/__init__.py
+++ b/src/surinort_ast/query/__init__.py
@@ -127,10 +127,6 @@ Public API Overview:
         query_first()   - Query for first match
         query_exists()  - Check if any match exists
 
-    Classes:
-        QueryResult     - Wrapper for query results with convenience methods
-        Q               - Fluent query builder (Phase 3)
-
     Exceptions:
         QueryError              - Base exception
         QuerySyntaxError        - Invalid query syntax
@@ -433,82 +429,6 @@ def query_exists(node: ASTNode | Sequence[ASTNode], selector: str) -> bool:
 
 
 # ============================================================================
-# Classes (to be implemented)
-# ============================================================================
-
-
-class QueryResult:
-    """
-    Wrapper for query results with convenience methods.
-
-    Provides a fluent interface for working with query results,
-    including filtering, iteration, and common operations.
-
-    Attributes:
-        nodes: List of matched AST nodes
-
-    Example:
-        >>> result = QueryResult(query(rule, "Option"))
-        >>> result.count()
-        5
-        >>> result.first()
-        <MsgOption>
-        >>> result.filter("SidOption").exists()
-        True
-
-    Methods:
-        first()     - Get first result or None
-        last()      - Get last result or None
-        count()     - Count results
-        exists()    - Check if any results
-        filter()    - Further filter results
-        __iter__()  - Iterate over results
-        __len__()   - Get count
-        __getitem__() - Access by index
-
-    Note:
-        Phase 3 feature - not included in MVP
-    """
-
-    # TODO: Implement in Phase 3
-
-
-class Q:
-    """
-    Fluent query builder for programmatic query construction.
-
-    Provides a Python API for building queries without string manipulation.
-    Useful for dynamic query construction and IDE autocompletion.
-
-    Example:
-        >>> # Build query programmatically
-        >>> query_obj = (
-        ...     Q("Rule")
-        ...     .with_attr("action", "alert")
-        ...     .descendant(Q("ContentOption").with_attr("pattern", "*admin*", "contains"))
-        ... )
-        >>> selector_string = query_obj.build()
-        >>> results = query(rule, selector_string)
-        >>>
-        >>> # Equivalent to: "Rule[action=alert] ContentOption[pattern*='admin']"
-
-    Methods:
-        with_attr()     - Add attribute filter
-        descendant()    - Add descendant combinator
-        child()         - Add child combinator
-        adjacent()      - Add adjacent sibling
-        sibling()       - Add general sibling
-        or_()           - Add union (OR)
-        build()         - Build selector string
-
-    Note:
-        Phase 3 feature - not included in MVP
-    """
-
-    # TODO: Implement in Phase 3
-
-
-# ============================================================================
 # Exceptions
 # ============================================================================
 
@@ -580,14 +500,9 @@ class InvalidSelectorError(QueryError):
 
 __all__ = [
     "InvalidSelectorError",
-    "Q",
-    # Exceptions
     "QueryError",
     "QueryExecutionError",
-    # Classes (Phase 3)
-    "QueryResult",
     "QuerySyntaxError",
-    # Core query functions
     "query",
     "query_all",
     "query_exists",
@@ -602,29 +517,6 @@ __all__ = [
 __author__ = "Marc Rivero López"
 __license__ = "GPL-3.0"
 
-# Implementation notes:
-#
-# Phase 1 (MVP - Foundation):
-# - Implement parser.py with basic Lark grammar
-# - Implement selectors.py with TypeSelector and AttributeSelector
-# - Implement executor.py with QueryExecutor(ASTVisitor)
-# - Implement query(), query_all(), query_first() functions
-# - Unit tests for basic functionality
-#
-# Phase 2 (Hierarchical Navigation):
-# - Add combinators.py for hierarchical logic
-# - Extend executor.py with context stack
-# - Support descendant, child, sibling combinators
-# - Integration tests with real corpus
-#
-# Phase 3 (Advanced Features):
-# - Add matchers.py for advanced attribute matching
-# - Implement pseudo-selectors
-# - Add QueryResult wrapper class
-# - Add Q fluent builder
-# - Performance optimizations
-# - Comprehensive documentation
-#
 # Design constraints:
 # - Must work with frozen Pydantic models
 # - Must be thread-safe (read-only)

--- a/src/surinort_ast/query/executor.py
+++ b/src/surinort_ast/query/executor.py
@@ -411,58 +411,6 @@ class QueryExecutor(ASTVisitor[list[ASTNode]]):
 
 
 # ============================================================================
-# Optimized Executors (Phase 3)
-# ============================================================================
-
-
-class IndexedQueryExecutor(QueryExecutor):
-    """
-    Query executor with pre-computed indices for fast lookups.
-
-    Builds type and attribute indices during initialization for
-    O(1) lookups instead of O(n) traversals. Useful for repeated
-    queries on large corpora.
-
-    Attributes:
-        type_index: Dict mapping node types to lists of nodes
-        attribute_indices: Dict of attribute-specific indices
-
-    Example:
-        >>> # Build indices for 30K rules
-        >>> executor = IndexedQueryExecutor.build(rules)
-        >>>
-        >>> # Fast type lookup
-        >>> results = executor.execute(chain)  # Uses index, not traversal
-
-    Implementation:
-        Phase 3 (optional): For performance-critical use cases
-        Trade-off: Memory usage vs. query speed
-    """
-
-    # TODO: Implement in Phase 3 (post-MVP)
-
-
-class StreamingQueryExecutor(QueryExecutor):
-    """
-    Query executor for streaming/incremental results.
-
-    Yields results as they are found instead of accumulating them.
-    Useful for large result sets or when processing can start before
-    query completes.
-
-    Example:
-        >>> executor = StreamingQueryExecutor(chain)
-        >>> for node in executor.execute_stream(rules):
-        ...     process(node)  # Process incrementally
-
-    Implementation:
-        Phase 3 (optional): For memory-constrained environments
-    """
-
-    # TODO: Implement in Phase 3 (post-MVP)
-
-
-# ============================================================================
 # Helper Functions
 # ============================================================================
 
@@ -497,10 +445,7 @@ def execute_query_first(
     selector_chain: Any,  # SelectorChain type
 ) -> ASTNode | None:
     """
-    Execute query and return first match.
-
-    More efficient than execute_query() when only first result needed.
-    Uses early exit optimization.
+    Execute query and return the first match, or None.
 
     Args:
         root: Single node or sequence of nodes
@@ -512,11 +457,7 @@ def execute_query_first(
     Example:
         >>> chain = parser.parse("SidOption")
         >>> sid_node = execute_query_first(rule, chain)
-
-    Implementation:
-        Phase 1: Execute with early exit flag
     """
-    # TODO: Implement early exit in Phase 1
     results = execute_query(root, selector_chain)
     return results[0] if results else None
 
@@ -526,9 +467,7 @@ def execute_query_exists(
     selector_chain: Any,  # SelectorChain type
 ) -> bool:
     """
-    Check if any node matches selector.
-
-    Most efficient existence check with immediate early exit.
+    Check whether any node matches the selector.
 
     Args:
         root: Single node or sequence of nodes
@@ -540,11 +479,7 @@ def execute_query_exists(
     Example:
         >>> chain = parser.parse("PcreOption")
         >>> has_pcre = execute_query_exists(rule, chain)
-
-    Implementation:
-        Phase 1: Execute with exists flag for fastest early exit
     """
-    # TODO: Implement in Phase 1
     return len(execute_query(root, selector_chain)) > 0
 
 
@@ -603,50 +538,3 @@ class ExecutionContext:
     def is_child_of(self, node: ASTNode, parent: ASTNode) -> bool:
         """Check if node is direct child of parent."""
         return self.get_parent() == parent
-
-
-# ============================================================================
-# Performance Utilities (Phase 3)
-# ============================================================================
-
-
-def estimate_query_cost(selector_chain: Any) -> int:  # SelectorChain type
-    """
-    Estimate computational cost of query.
-
-    Returns cost estimate for query execution, useful for
-    optimization decisions.
-
-    Args:
-        selector_chain: Selector chain to estimate
-
-    Returns:
-        Cost estimate (higher = more expensive)
-
-    Implementation:
-        Phase 3: Heuristic-based cost model
-    """
-    # TODO: Implement in Phase 3
-    return 0
-
-
-def optimize_selector_chain(selector_chain: Any) -> Any:  # SelectorChain type
-    """
-    Optimize selector chain for faster execution.
-
-    Applies optimizations like:
-        - Reordering compound selectors (fail-fast first)
-        - Combining adjacent type selectors
-        - Simplifying redundant conditions
-
-    Args:
-        selector_chain: Original selector chain
-
-    Returns:
-        Optimized selector chain
-
-    Implementation:
-        Phase 3: Query optimization pass
-    """
-    # TODO: Implement in Phase 3
-    return selector_chain

--- a/src/surinort_ast/query/parser.py
+++ b/src/surinort_ast/query/parser.py
@@ -525,24 +525,21 @@ def validate_selector_chain(chain: SelectorChain) -> None:
 
 def normalize_selector(selector: str) -> str:
     """
-    Normalize selector string for consistent parsing.
+    Strip surrounding whitespace from a selector string.
 
-    Performs:
-        - Whitespace normalization
-        - Quote normalization
-        - Escape sequence handling
+    Internal whitespace is tolerated by the Lark grammar, so only the
+    leading and trailing whitespace needs trimming before parsing.
 
     Args:
         selector: Raw selector string
 
     Returns:
-        Normalized selector string
+        Selector string with surrounding whitespace removed
 
     Example:
-        >>> normalize_selector("  Rule  [  action = alert  ]  ")
-        "Rule[action=alert]"
+        >>> normalize_selector("  Rule[action=alert]  ")
+        'Rule[action=alert]'
     """
-    # TODO: Implement in Phase 1
     return selector.strip()
 
 

--- a/src/surinort_ast/query/selectors.py
+++ b/src/surinort_ast/query/selectors.py
@@ -87,39 +87,24 @@ class TypeSelector(Selector):
     Selects nodes by type name.
 
     Matches nodes where node.node_type equals the specified type name.
-    Optionally matches base classes (e.g., "AddressExpr" matches all
-    address types).
 
     Attributes:
         type_name: Node type to match (e.g., "ContentOption")
-        match_subclasses: If True, match derived types too
 
     Example:
-        >>> # Exact type match
         >>> selector = TypeSelector("ContentOption")
         >>> selector.matches(ContentOption(pattern=b"test"))
         True
-        >>>
-        >>> # Base class match
-        >>> selector = TypeSelector("AddressExpr", match_subclasses=True)
-        >>> selector.matches(IPAddress(value="192.168.1.1", version=4))
-        True
-
-    Implementation:
-        Phase 1: Exact type matching only
-        Phase 2: Subclass matching with isinstance()
     """
 
-    def __init__(self, type_name: str, match_subclasses: bool = False) -> None:
+    def __init__(self, type_name: str) -> None:
         """
         Initialize type selector.
 
         Args:
             type_name: Node type name to match
-            match_subclasses: Match derived types if True
         """
         self.type_name = type_name
-        self.match_subclasses = match_subclasses
 
     def matches(self, node: ASTNode) -> bool:
         """
@@ -130,31 +115,22 @@ class TypeSelector(Selector):
 
         Returns:
             True if node type matches
-
-        Implementation:
-            Phase 1: Simple string comparison with node.node_type
-            Phase 2: Add isinstance() check for subclass matching
         """
-        # Phase 1: Simple exact type matching
-        if self.match_subclasses:
-            # Phase 2 feature - not implemented yet
-            raise NotImplementedError("Subclass matching not yet implemented")
         return node.node_type == self.type_name
 
     def __repr__(self) -> str:
         """String representation."""
-        subclass_marker = "~" if self.match_subclasses else ""
-        return f"TypeSelector({subclass_marker}{self.type_name})"
+        return f"TypeSelector({self.type_name})"
 
     def __eq__(self, other: object) -> bool:
         """Equality comparison."""
         if not isinstance(other, TypeSelector):
             return False
-        return self.type_name == other.type_name and self.match_subclasses == other.match_subclasses
+        return self.type_name == other.type_name
 
     def __hash__(self) -> int:
-        """Hash value based on type_name and match_subclasses."""
-        return hash((self.type_name, self.match_subclasses))
+        """Hash value based on type_name."""
+        return hash(self.type_name)
 
 
 class UniversalSelector(Selector):
@@ -788,34 +764,3 @@ class Combinator(Enum):
     CHILD = ">"  # Direct child only
     ADJACENT = "+"  # Immediately following sibling
     GENERAL = "~"  # Any following sibling
-
-
-# ============================================================================
-# Helper Functions
-# ============================================================================
-
-
-def create_selector(selector_type: str, **kwargs: Any) -> Selector:
-    """
-    Factory function for creating selectors.
-
-    Args:
-        selector_type: Type of selector to create
-        **kwargs: Selector-specific arguments
-
-    Returns:
-        Selector instance
-
-    Raises:
-        InvalidSelectorError: If selector_type is unknown
-
-    Example:
-        >>> selector = create_selector("type", type_name="Rule")
-        >>> selector = create_selector("attribute", attribute="value", operator="=", value=1)
-
-    Implementation:
-        Phase 1: Basic factory for type and attribute selectors
-        Phase 3: Complete factory for all selector types
-    """
-    # TODO: Implement in Phase 1
-    raise NotImplementedError("create_selector not yet implemented")

--- a/tests/unit/test_query_complete.py
+++ b/tests/unit/test_query_complete.py
@@ -911,17 +911,8 @@ class TestSelectorChainValidation:
             )
 
 
-class TestNotImplementedFeatures:
-    """Test that Phase 2/3 features properly raise NotImplementedError."""
-
-    def test_type_selector_subclass_matching_not_implemented(self):
-        """Test subclass matching raises NotImplementedError."""
-        selector = TypeSelector("Option", match_subclasses=True)
-        rule = parse_rule("alert tcp any any -> any 80 (sid:1;)")
-        sid_node = query_first(rule, "SidOption")
-
-        with pytest.raises(NotImplementedError):
-            selector.matches(sid_node)
+class TestSelectorBehavior:
+    """Behavioural tests for selector matching."""
 
     def test_attribute_selector_comparison_operators_work(self):
         """Test comparison operators work correctly."""
@@ -956,13 +947,9 @@ class TestNotImplementedFeatures:
         selector_lte_fail = AttributeSelector("value", "<=", 1000000)
         assert selector_lte_fail.matches(sid_node) is False
 
-    def test_multi_selector_chain_not_implemented(self):
-        """Test multi-selector chains raise NotImplementedError."""
+    def test_single_selector_chain_parses(self):
+        """A bare type selector parses to a chain with one selector."""
         parser = QueryParser()
-
-        # Phase 2 feature - descendant combinator with whitespace
-        # This will parse but the executor doesn't support it yet
-        # For now, just test that parsing a complex chain works
         chain = parser.parse("Rule")
         assert len(chain.selectors) == 1
 


### PR DESCRIPTION
First pass of a clean-code / clean-architecture refactor.

## Problem
The `query` module shipped a misleading public surface: empty "Phase 3 / not in MVP" stub classes, a factory that only raised `NotImplementedError`, helpers returning hardcoded placeholders, and a `TypeSelector.match_subclasses` knob whose matcher raised `NotImplementedError` (and which the grammar never produces). Ten `# TODO: Implement in Phase N` markers and a speculative roadmap comment accompanied them.

## Change
Remove contracts the package does not fulfil, and make the surviving helpers honest.

**Removed (all dead — no callers in `src/` or `tests/`, not re-exported):**
- `query.Q`, `query.QueryResult` empty stub classes (dropped from `__all__`)
- `selectors.create_selector` (`raise NotImplementedError`)
- `executor.IndexedQueryExecutor` / `StreamingQueryExecutor` empty stubs
- `executor.estimate_query_cost` (returned `0`), `optimize_selector_chain` (no-op)
- `TypeSelector.match_subclasses` (unreachable; `matches()` raised when set)

**Made honest:**
- `execute_query_first` / `execute_query_exists`: dropped stale TODOs and false "early exit" docstring claims
- `normalize_selector`: docstring now matches actual `strip()` behaviour
- removed the Phase 1/2/3 roadmap comment; tests no longer reference removed features

## Verification
- `ruff check`, `ruff format --check`, `mypy --strict` — all pass
- Full non-slow suite: **1735 passed**

Net: 5 files, +17 / −308.

🤖 Generated with [Claude Code](https://claude.com/claude-code)