### PR TITLE
feat(query): selector factory, subclass matching, QueryResult, Q builder

### DIFF
--- a/src/surinort_ast/query/__init__.py
+++ b/src/surinort_ast/query/__init__.py
@@ -129,7 +129,10 @@ Public API Overview:
 
     Classes:
         QueryResult     - Wrapper for query results with convenience methods
-        Q               - Fluent query builder (Phase 3)
+        Q               - Fluent query builder
+
+    Factory:
+        create_selector - Build a selector object from a type + kwargs
 
     Exceptions:
         QueryError              - Base exception
@@ -153,9 +156,13 @@ See Also:
     - tests/unit/query/: Test suite
 """
 
-from collections.abc import Sequence
+from __future__ import annotations
+
+from collections.abc import Iterator, Sequence
 
 from surinort_ast.core.nodes import ASTNode
+
+from .selectors import create_selector
 
 # ============================================================================
 # Module Status - EXPERIMENTAL/ALPHA
@@ -433,7 +440,7 @@ def query_exists(node: ASTNode | Sequence[ASTNode], selector: str) -> bool:
 
 
 # ============================================================================
-# Classes (to be implemented)
+# Result wrapper and fluent builder
 # ============================================================================
 
 
@@ -441,71 +448,206 @@ class QueryResult:
     """
     Wrapper for query results with convenience methods.
 
-    Provides a fluent interface for working with query results,
-    including filtering, iteration, and common operations.
-
-    Attributes:
-        nodes: List of matched AST nodes
+    Provides a fluent interface for working with query results, including
+    counting, first/last access, existence checks, and further filtering.
 
     Example:
-        >>> result = QueryResult(query(rule, "Option"))
+        >>> result = QueryResult(query(rule, "ContentOption, SidOption"))
         >>> result.count()
-        5
-        >>> result.first()
-        <MsgOption>
+        2
+        >>> result.first() is not None
+        True
         >>> result.filter("SidOption").exists()
         True
-
-    Methods:
-        first()     - Get first result or None
-        last()      - Get last result or None
-        count()     - Count results
-        exists()    - Check if any results
-        filter()    - Further filter results
-        __iter__()  - Iterate over results
-        __len__()   - Get count
-        __getitem__() - Access by index
-
-    Note:
-        Phase 3 feature - not included in MVP
     """
 
-    # TODO: Implement in Phase 3
+    def __init__(self, nodes: Sequence[ASTNode], root: ASTNode | None = None) -> None:
+        """
+        Args:
+            nodes: Matched AST nodes.
+            root: Optional root the nodes were queried from (unused by the
+                current convenience methods; kept for future re-querying).
+        """
+        self._nodes: list[ASTNode] = list(nodes)
+        self._root = root
+
+    @property
+    def nodes(self) -> list[ASTNode]:
+        """Return a copy of the matched nodes."""
+        return list(self._nodes)
+
+    def first(self) -> ASTNode | None:
+        """Return the first matched node, or None."""
+        return self._nodes[0] if self._nodes else None
+
+    def last(self) -> ASTNode | None:
+        """Return the last matched node, or None."""
+        return self._nodes[-1] if self._nodes else None
+
+    def count(self) -> int:
+        """Return the number of matched nodes."""
+        return len(self._nodes)
+
+    def exists(self) -> bool:
+        """Return True if there is at least one matched node."""
+        return bool(self._nodes)
+
+    def filter(self, selector: str) -> QueryResult:
+        """
+        Narrow the result to nodes that themselves match a simple selector.
+
+        Args:
+            selector: A simple selector (type/attribute/compound/union, no
+                combinators) tested against each node directly.
+
+        Returns:
+            A new QueryResult with the surviving nodes.
+
+        Raises:
+            QuerySyntaxError: If the selector uses combinators.
+        """
+        return QueryResult(
+            [node for node in self._nodes if _node_matches_selector(node, selector)],
+            self._root,
+        )
+
+    def __iter__(self) -> Iterator[ASTNode]:
+        return iter(self._nodes)
+
+    def __len__(self) -> int:
+        return len(self._nodes)
+
+    def __getitem__(self, index: int) -> ASTNode:
+        return self._nodes[index]
+
+    def __repr__(self) -> str:
+        return f"QueryResult({len(self._nodes)} nodes)"
+
+
+# Friendly operator aliases accepted by Q.with_attr, mapped to grammar operators.
+_ATTR_OPERATORS = {
+    "equals": "=",
+    "eq": "=",
+    "not_equals": "!=",
+    "ne": "!=",
+    "gt": ">",
+    "lt": "<",
+    "gte": ">=",
+    "lte": "<=",
+    "contains": "*=",
+    "startswith": "^=",
+    "endswith": "$=",
+}
+
+
+def _format_attr_value(value: object) -> str:
+    """Format a Python value as a selector attribute value (STRING/NUMBER/IDENT)."""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int | float):
+        return str(value)
+    text = str(value)
+    if "'" not in text:
+        return f"'{text}'"
+    if '"' not in text:
+        return f'"{text}"'
+    return "'" + text.replace("'", "") + "'"
+
+
+def _node_matches_selector(node: ASTNode, selector: str) -> bool:
+    """Test a single node against a simple (combinator-free) selector string."""
+    from .parser import QueryParser
+
+    chain = QueryParser().parse(selector)
+    if getattr(chain, "combinators", None):
+        raise QuerySyntaxError(
+            "QueryResult.filter() supports only simple selectors (no combinators)"
+        )
+    sel = chain.selectors[0]
+    try:
+        return bool(sel.matches(node))
+    except TypeError:
+        # Pseudo-selectors require an execution context, which a standalone
+        # node test cannot provide.
+        return bool(sel.matches(node, None))
 
 
 class Q:
     """
-    Fluent query builder for programmatic query construction.
+    Fluent query builder for programmatic selector construction.
 
-    Provides a Python API for building queries without string manipulation.
-    Useful for dynamic query construction and IDE autocompletion.
+    Builds a selector string without manual string manipulation; the result of
+    :meth:`build` round-trips through :func:`query`.
 
     Example:
-        >>> # Build query programmatically
-        >>> query_obj = (
+        >>> selector = (
         ...     Q("Rule")
         ...     .with_attr("action", "alert")
-        ...     .descendant(Q("ContentOption").with_attr("pattern", "*admin*", "contains"))
+        ...     .descendant(Q("ContentOption"))
+        ...     .build()
         ... )
-        >>> selector_string = query_obj.build()
-        >>> results = query(rule, selector_string)
-        >>>
-        >>> # Equivalent to: "Rule[action=alert] ContentOption[pattern*='admin']"
-
-    Methods:
-        with_attr()     - Add attribute filter
-        descendant()    - Add descendant combinator
-        child()         - Add child combinator
-        adjacent()      - Add adjacent sibling
-        sibling()       - Add general sibling
-        or_()           - Add union (OR)
-        build()         - Build selector string
-
-    Note:
-        Phase 3 feature - not included in MVP
+        >>> selector
+        "Rule[action='alert'] ContentOption"
     """
 
-    # TODO: Implement in Phase 3
+    def __init__(self, type_name: str | None = None) -> None:
+        """
+        Args:
+            type_name: Optional initial type selector (e.g. "Rule"). Omit for
+                a universal-style start built up purely from attributes.
+        """
+        self._selector = "" if type_name is None else str(type_name)
+
+    def with_attr(self, name: str, value: object = None, operator: str = "=") -> Q:
+        """
+        Append an attribute filter ``[name op value]`` (or ``[name]`` for existence).
+
+        Args:
+            name: Attribute name.
+            value: Value to compare; omit for an existence check.
+            operator: Grammar operator ("=", "!=", ">", ...) or a friendly
+                alias ("equals", "contains", "startswith", ...).
+        """
+        op = _ATTR_OPERATORS.get(operator, operator)
+        if value is None:
+            self._selector += f"[{name}]"
+        else:
+            self._selector += f"[{name}{op}{_format_attr_value(value)}]"
+        return self
+
+    def descendant(self, other: Q | str) -> Q:
+        """Append a descendant combinator (space) followed by ``other``."""
+        return self._combine(" ", other)
+
+    def child(self, other: Q | str) -> Q:
+        """Append a child combinator (>) followed by ``other``."""
+        return self._combine(" > ", other)
+
+    def adjacent(self, other: Q | str) -> Q:
+        """Append an adjacent-sibling combinator (+) followed by ``other``."""
+        return self._combine(" + ", other)
+
+    def sibling(self, other: Q | str) -> Q:
+        """Append a general-sibling combinator (~) followed by ``other``."""
+        return self._combine(" ~ ", other)
+
+    def or_(self, other: Q | str) -> Q:
+        """Append a union (comma) followed by ``other``."""
+        return self._combine(", ", other)
+
+    def _combine(self, combinator: str, other: Q | str) -> Q:
+        self._selector += f"{combinator}{other.build() if isinstance(other, Q) else other}"
+        return self
+
+    def build(self) -> str:
+        """Return the assembled selector string."""
+        return self._selector
+
+    def __str__(self) -> str:
+        return self._selector
+
+    def __repr__(self) -> str:
+        return f"Q({self._selector!r})"
 
 
 # ============================================================================
@@ -581,13 +723,11 @@ class InvalidSelectorError(QueryError):
 __all__ = [
     "InvalidSelectorError",
     "Q",
-    # Exceptions
     "QueryError",
     "QueryExecutionError",
-    # Classes (Phase 3)
     "QueryResult",
     "QuerySyntaxError",
-    # Core query functions
+    "create_selector",
     "query",
     "query_all",
     "query_exists",

--- a/src/surinort_ast/query/parser.py
+++ b/src/surinort_ast/query/parser.py
@@ -14,6 +14,8 @@ from typing import Any
 
 from lark import Lark, Token, Transformer
 
+from .selectors import UnionSelector
+
 # ============================================================================
 # Parser Implementation (Phase 1)
 # ============================================================================
@@ -487,22 +489,24 @@ class SelectorTransformer(Transformer[Any, Any]):
 # ============================================================================
 
 
-def validate_selector_chain(chain: SelectorChain) -> None:
+def validate_selector_chain(chain: SelectorChain | UnionSelector) -> None:
     """
     Validate semantic correctness of selector chain.
+
+    A union query (``A, B``) transforms to a :class:`UnionSelector`; each of its
+    sub-chains is validated individually.
 
     Checks for:
         - Empty selector chains
         - Mismatched combinator/selector counts
 
     Args:
-        chain: Parsed selector chain
+        chain: Parsed selector chain or union of chains.
 
     Raises:
         InvalidSelectorError: If chain has semantic errors
     """
     from . import InvalidSelectorError
-    from .selectors import UnionSelector
 
     # UnionSelector wraps multiple chains; validate each sub-chain individually
     if isinstance(chain, UnionSelector):

--- a/src/surinort_ast/query/registry.py
+++ b/src/surinort_ast/query/registry.py
@@ -1,0 +1,43 @@
+"""
+Runtime registry mapping AST node type names to their classes.
+
+The query engine identifies nodes by ``node.node_type`` (the class name).
+For subclass-aware matching and indexed execution it also needs to resolve a
+type name back to its Python class so that ``isinstance`` checks can include
+derived types. This module builds that mapping once by introspecting the
+``ASTNode`` class hierarchy defined in :mod:`surinort_ast.core.nodes`, so it
+never drifts from the node definitions.
+
+Licensed under GNU General Public License v3.0
+Author: Marc Rivero | @seifreed | mriverolopez@gmail.com
+"""
+
+from __future__ import annotations
+
+from ..core.nodes import ASTNode
+
+
+def _build_registry() -> dict[str, type[ASTNode]]:
+    """Walk the ASTNode subclass tree and map class name -> class."""
+    registry: dict[str, type[ASTNode]] = {}
+    stack: list[type[ASTNode]] = [ASTNode]
+    seen: set[type[ASTNode]] = set()
+    while stack:
+        cls = stack.pop()
+        if cls in seen:
+            continue
+        seen.add(cls)
+        registry[cls.__name__] = cls
+        stack.extend(cls.__subclasses__())
+    return registry
+
+
+NODE_TYPE_REGISTRY: dict[str, type[ASTNode]] = _build_registry()
+
+
+def resolve_node_type(name: str) -> type[ASTNode] | None:
+    """Return the AST node class for ``name``, or None if it is unknown."""
+    return NODE_TYPE_REGISTRY.get(name)
+
+
+__all__ = ["NODE_TYPE_REGISTRY", "resolve_node_type"]

--- a/src/surinort_ast/query/selectors.py
+++ b/src/surinort_ast/query/selectors.py
@@ -15,6 +15,8 @@ from typing import TYPE_CHECKING, Any
 
 from surinort_ast.core.nodes import ASTNode
 
+from .registry import resolve_node_type
+
 # Avoid circular imports - ExecutionContext, QueryExecutor, SelectorChain
 # are imported locally where needed
 if TYPE_CHECKING:
@@ -104,10 +106,6 @@ class TypeSelector(Selector):
         >>> selector = TypeSelector("AddressExpr", match_subclasses=True)
         >>> selector.matches(IPAddress(value="192.168.1.1", version=4))
         True
-
-    Implementation:
-        Phase 1: Exact type matching only
-        Phase 2: Subclass matching with isinstance()
     """
 
     def __init__(self, type_name: str, match_subclasses: bool = False) -> None:
@@ -125,20 +123,23 @@ class TypeSelector(Selector):
         """
         Test if node type matches.
 
+        With ``match_subclasses`` the node matches the named type or any of
+        its AST subclasses (e.g. ``TypeSelector("Option", match_subclasses=True)``
+        matches ``SidOption``, ``MsgOption``, ...). Otherwise the match is on the
+        exact ``node_type`` name.
+
         Args:
             node: AST node to test
 
         Returns:
             True if node type matches
-
-        Implementation:
-            Phase 1: Simple string comparison with node.node_type
-            Phase 2: Add isinstance() check for subclass matching
         """
-        # Phase 1: Simple exact type matching
         if self.match_subclasses:
-            # Phase 2 feature - not implemented yet
-            raise NotImplementedError("Subclass matching not yet implemented")
+            target = resolve_node_type(self.type_name)
+            if target is not None:
+                return isinstance(node, target)
+            # Unknown type name: fall back to exact-name matching.
+            return node.node_type == self.type_name
         return node.node_type == self.type_name
 
     def __repr__(self) -> str:
@@ -795,9 +796,36 @@ class Combinator(Enum):
 # ============================================================================
 
 
+_VALID_PSEUDO_TYPES = frozenset(
+    {
+        "first",
+        "first-child",
+        "last",
+        "last-child",
+        "empty",
+        "not-empty",
+        "even",
+        "odd",
+        "has",
+        "not",
+        "within",
+        "nth",
+    }
+)
+
+
 def create_selector(selector_type: str, **kwargs: Any) -> Selector:
     """
-    Factory function for creating selectors.
+    Factory for creating selectors from a type string and keyword arguments.
+
+    Supported ``selector_type`` values and their required kwargs:
+
+    - ``"type"``: ``type_name`` (optional ``match_subclasses``)
+    - ``"universal"``: none
+    - ``"attribute"``: ``attribute``, ``operator`` (optional ``value``)
+    - ``"compound"``: ``selectors``
+    - ``"union"``: ``selectors``
+    - ``"pseudo"``: ``pseudo_type`` (optional ``argument``)
 
     Args:
         selector_type: Type of selector to create
@@ -807,15 +835,41 @@ def create_selector(selector_type: str, **kwargs: Any) -> Selector:
         Selector instance
 
     Raises:
-        InvalidSelectorError: If selector_type is unknown
+        InvalidSelectorError: If ``selector_type`` is unknown, required
+            arguments are missing, or an argument is invalid.
 
     Example:
         >>> selector = create_selector("type", type_name="Rule")
-        >>> selector = create_selector("attribute", attribute="value", operator="=", value=1)
-
-    Implementation:
-        Phase 1: Basic factory for type and attribute selectors
-        Phase 3: Complete factory for all selector types
+        >>> selector = create_selector("attribute", attribute="value", operator=">", value=1)
     """
-    # TODO: Implement in Phase 1
-    raise NotImplementedError("create_selector not yet implemented")
+    from . import InvalidSelectorError
+
+    def _require(*names: str) -> None:
+        missing = [name for name in names if name not in kwargs]
+        if missing:
+            raise InvalidSelectorError(
+                f"create_selector({selector_type!r}) requires: {', '.join(missing)}"
+            )
+
+    if selector_type == "type":
+        _require("type_name")
+        return TypeSelector(kwargs["type_name"], kwargs.get("match_subclasses", False))
+    if selector_type == "universal":
+        return UniversalSelector()
+    if selector_type == "attribute":
+        _require("attribute", "operator")
+        return AttributeSelector(kwargs["attribute"], kwargs["operator"], kwargs.get("value"))
+    if selector_type == "compound":
+        _require("selectors")
+        return CompoundSelector(kwargs["selectors"])
+    if selector_type == "union":
+        _require("selectors")
+        return UnionSelector(kwargs["selectors"])
+    if selector_type == "pseudo":
+        _require("pseudo_type")
+        pseudo_type = kwargs["pseudo_type"]
+        if pseudo_type not in _VALID_PSEUDO_TYPES:
+            raise InvalidSelectorError(f"Invalid pseudo-selector type: {pseudo_type}")
+        return PseudoSelector(pseudo_type, kwargs.get("argument"))
+
+    raise InvalidSelectorError(f"Unknown selector type: {selector_type}")

--- a/tests/unit/test_query_builders.py
+++ b/tests/unit/test_query_builders.py
@@ -1,0 +1,201 @@
+"""Tests for the query selector factory, subclass matching, QueryResult, and Q builder."""
+
+from __future__ import annotations
+
+import pytest
+
+from surinort_ast import parse_rule
+from surinort_ast.query import (
+    InvalidSelectorError,
+    Q,
+    QueryResult,
+    QuerySyntaxError,
+    create_selector,
+    query,
+)
+from surinort_ast.query.selectors import (
+    AttributeSelector,
+    CompoundSelector,
+    PseudoSelector,
+    TypeSelector,
+    UnionSelector,
+    UniversalSelector,
+)
+
+RULE_TEXT = 'alert tcp any any -> any 80 (msg:"t"; content:"admin"; sid:1000001; rev:1;)'
+
+
+@pytest.fixture
+def rule():
+    return parse_rule(RULE_TEXT)
+
+
+class TestCreateSelector:
+    def test_type(self):
+        sel = create_selector("type", type_name="Rule")
+        assert isinstance(sel, TypeSelector)
+        assert sel.type_name == "Rule"
+        assert sel.match_subclasses is False
+
+    def test_type_with_subclasses(self):
+        sel = create_selector("type", type_name="Option", match_subclasses=True)
+        assert isinstance(sel, TypeSelector)
+        assert sel.match_subclasses is True
+
+    def test_universal(self):
+        assert isinstance(create_selector("universal"), UniversalSelector)
+
+    def test_attribute(self):
+        sel = create_selector("attribute", attribute="value", operator=">", value=1)
+        assert isinstance(sel, AttributeSelector)
+        assert sel.attribute == "value"
+        assert sel.operator == ">"
+        assert sel.value == 1
+
+    def test_compound(self):
+        inner = [TypeSelector("Rule"), AttributeSelector("action", "=", "alert")]
+        sel = create_selector("compound", selectors=inner)
+        assert isinstance(sel, CompoundSelector)
+
+    def test_union(self):
+        inner = [TypeSelector("ContentOption"), TypeSelector("PcreOption")]
+        assert isinstance(create_selector("union", selectors=inner), UnionSelector)
+
+    def test_pseudo(self):
+        assert isinstance(create_selector("pseudo", pseudo_type="first"), PseudoSelector)
+
+    def test_unknown_type_raises(self):
+        with pytest.raises(InvalidSelectorError):
+            create_selector("bogus")
+
+    def test_missing_required_kwargs_raises(self):
+        with pytest.raises(InvalidSelectorError):
+            create_selector("type")
+        with pytest.raises(InvalidSelectorError):
+            create_selector("attribute", attribute="value")  # missing operator
+        with pytest.raises(InvalidSelectorError):
+            create_selector("pseudo")
+
+    def test_invalid_pseudo_type_raises(self):
+        with pytest.raises(InvalidSelectorError):
+            create_selector("pseudo", pseudo_type="not-a-pseudo")
+
+    def test_invalid_operator_raises(self):
+        with pytest.raises(InvalidSelectorError):
+            create_selector("attribute", attribute="value", operator="~~")
+
+
+class TestSubclassMatching:
+    def test_exact_does_not_match_base(self, rule):
+        sid = query(rule, "SidOption")[0]
+        assert TypeSelector("Option").matches(sid) is False
+
+    def test_subclass_matches_base(self, rule):
+        sid = query(rule, "SidOption")[0]
+        assert TypeSelector("Option", match_subclasses=True).matches(sid) is True
+
+    def test_subclass_address_hierarchy(self, rule):
+        # Header src_addr is an AddressExpr subclass (AnyAddress here)
+        addr = rule.header.src_addr
+        assert TypeSelector("AddressExpr", match_subclasses=True).matches(addr) is True
+        assert TypeSelector("AddressExpr").matches(addr) is False
+
+    def test_unknown_type_name_falls_back_to_exact(self, rule):
+        sid = query(rule, "SidOption")[0]
+        sel = TypeSelector("DefinitelyNotARealType", match_subclasses=True)
+        assert sel.matches(sid) is False
+
+    def test_subclass_flag_in_equality_and_hash(self):
+        a = TypeSelector("Option", match_subclasses=True)
+        b = TypeSelector("Option", match_subclasses=True)
+        c = TypeSelector("Option", match_subclasses=False)
+        assert a == b
+        assert a != c
+        assert hash(a) == hash(b)
+
+
+class TestQueryResult:
+    def test_basic_accessors(self, rule):
+        res = QueryResult(query(rule, "ContentOption, SidOption"), root=rule)
+        assert res.count() == 2
+        assert len(res) == 2
+        assert res.exists() is True
+        assert res.first().node_type == "ContentOption"
+        assert res.last().node_type == "SidOption"
+        assert res[0].node_type == "ContentOption"
+        assert [n.node_type for n in res] == ["ContentOption", "SidOption"]
+        assert len(res.nodes) == 2
+
+    def test_empty(self):
+        res = QueryResult([])
+        assert res.count() == 0
+        assert res.exists() is False
+        assert res.first() is None
+        assert res.last() is None
+
+    def test_filter_narrows(self, rule):
+        res = QueryResult(query(rule, "ContentOption, SidOption"), root=rule)
+        filtered = res.filter("SidOption")
+        assert filtered.count() == 1
+        assert filtered.first().node_type == "SidOption"
+
+    def test_filter_attribute(self, rule):
+        res = QueryResult(query(rule, "SidOption"), root=rule)
+        assert res.filter("SidOption[value=1000001]").exists() is True
+        assert res.filter("SidOption[value=999]").exists() is False
+
+    def test_filter_rejects_combinators(self, rule):
+        res = QueryResult(query(rule, "SidOption"))
+        with pytest.raises(QuerySyntaxError):
+            res.filter("Rule > Header")
+
+    def test_repr(self):
+        assert "2 nodes" in repr(QueryResult([object(), object()]))  # type: ignore[list-item]
+
+
+class TestQBuilder:
+    def test_simple_type(self):
+        assert Q("Rule").build() == "Rule"
+
+    def test_with_attr_equals(self):
+        assert Q("Rule").with_attr("action", "alert").build() == "Rule[action='alert']"
+
+    def test_with_attr_numeric(self):
+        assert Q("SidOption").with_attr("value", 1000, "gt").build() == "SidOption[value>1000]"
+
+    def test_with_attr_existence(self):
+        assert Q("ContentOption").with_attr("modifiers").build() == "ContentOption[modifiers]"
+
+    def test_operator_aliases(self):
+        assert Q("M").with_attr("text", "x", "contains").build() == "M[text*='x']"
+        assert Q("M").with_attr("text", "x", "startswith").build() == "M[text^='x']"
+        assert Q("M").with_attr("text", "x", "endswith").build() == "M[text$='x']"
+
+    def test_combinators(self):
+        assert Q("Rule").descendant(Q("ContentOption")).build() == "Rule ContentOption"
+        assert Q("Rule").child(Q("Header")).build() == "Rule > Header"
+        assert Q("A").adjacent(Q("B")).build() == "A + B"
+        assert Q("A").sibling(Q("B")).build() == "A ~ B"
+        assert Q("A").or_(Q("B")).build() == "A, B"
+
+    def test_combinator_accepts_string(self):
+        assert Q("Rule").descendant("ContentOption").build() == "Rule ContentOption"
+
+    def test_str_and_repr(self):
+        q = Q("Rule")
+        assert str(q) == "Rule"
+        assert repr(q) == "Q('Rule')"
+
+    def test_roundtrip_through_query(self, rule):
+        built = Q("ContentOption").build()
+        assert len(query(rule, built)) == len(query(rule, "ContentOption"))
+
+    def test_roundtrip_attribute_through_query(self, rule):
+        built = Q("SidOption").with_attr("value", 1000001).build()
+        results = query(rule, built)
+        assert len(results) == 1
+        assert results[0].node_type == "SidOption"
+
+    def test_roundtrip_descendant_through_query(self, rule):
+        built = Q("Rule").descendant(Q("ContentOption")).build()
+        assert len(query(rule, built)) == 1

--- a/tests/unit/test_query_complete.py
+++ b/tests/unit/test_query_complete.py
@@ -911,17 +911,17 @@ class TestSelectorChainValidation:
             )
 
 
-class TestNotImplementedFeatures:
-    """Test that Phase 2/3 features properly raise NotImplementedError."""
+class TestSelectorBehavior:
+    """Behavioural tests for selector matching."""
 
-    def test_type_selector_subclass_matching_not_implemented(self):
-        """Test subclass matching raises NotImplementedError."""
+    def test_type_selector_subclass_matching(self):
+        """Subclass matching matches a base type against its derived types."""
         selector = TypeSelector("Option", match_subclasses=True)
         rule = parse_rule("alert tcp any any -> any 80 (sid:1;)")
         sid_node = query_first(rule, "SidOption")
 
-        with pytest.raises(NotImplementedError):
-            selector.matches(sid_node)
+        assert selector.matches(sid_node) is True
+        assert TypeSelector("Option").matches(sid_node) is False
 
     def test_attribute_selector_comparison_operators_work(self):
         """Test comparison operators work correctly."""
@@ -956,13 +956,9 @@ class TestNotImplementedFeatures:
         selector_lte_fail = AttributeSelector("value", "<=", 1000000)
         assert selector_lte_fail.matches(sid_node) is False
 
-    def test_multi_selector_chain_not_implemented(self):
-        """Test multi-selector chains raise NotImplementedError."""
+    def test_single_selector_chain_parses(self):
+        """A bare type selector parses to a chain with one selector."""
         parser = QueryParser()
-
-        # Phase 2 feature - descendant combinator with whitespace
-        # This will parse but the executor doesn't support it yet
-        # For now, just test that parsing a complex chain works
         chain = parser.parse("Rule")
         assert len(chain.selectors) == 1
 


### PR DESCRIPTION
Phase 1 of implementing the pending `query/` stubs as real features (per the approved plan; supersedes the now-closed removal PR #106).

## Implemented
- **`create_selector(selector_type, **kwargs)`** — factory → Type/Universal/Attribute/Compound/Union/Pseudo selectors, with required-arg + pseudo-type validation (`InvalidSelectorError`).
- **`TypeSelector.match_subclasses`** — matches a base type against its AST subclasses via `isinstance`, backed by a new **`query/registry.py`** (`NODE_TYPE_REGISTRY` built by introspecting the `ASTNode` hierarchy — no hand-maintained list). Unknown names fall back to exact matching. *(API-level; a query-string syntax for subclass matching is a noted optional follow-up.)*
- **`QueryResult`** — `first/last/count/exists/filter/__iter__/__len__/__getitem__/nodes`; `filter()` narrows to nodes matching a simple selector and rejects combinators.
- **`Q`** — fluent builder; `build()` round-trips through `query()`. Friendly operator aliases (`contains`→`*=`, etc.) and all combinators.

## Incidental fix
`validate_selector_chain` accepted `SelectorChain` but already handled `UnionSelector` at runtime (a `cast` at the call site hid this). Widened its parameter type to `SelectorChain | UnionSelector` so the pinned pre-commit mypy agrees with `mypy src/ --strict`.

## Verification
- `ruff`, `ruff format --check`, `mypy --strict` (incl. pinned pre-commit mypy) — clean.
- `tests/unit/test_query_builders.py` — 33 new tests. Full non-slow suite: **1769 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)