### PR TITLE
feat(query): indexed/streaming executors + cost/optimization utilities

### DIFF
--- a/src/surinort_ast/query/__init__.py
+++ b/src/surinort_ast/query/__init__.py
@@ -129,7 +129,10 @@ Public API Overview:
 
     Classes:
         QueryResult     - Wrapper for query results with convenience methods
-        Q               - Fluent query builder (Phase 3)
+        Q               - Fluent query builder
+
+    Factory:
+        create_selector - Build a selector object from a type + kwargs
 
     Exceptions:
         QueryError              - Base exception
@@ -153,9 +156,13 @@ See Also:
     - tests/unit/query/: Test suite
 """
 
-from collections.abc import Sequence
+from __future__ import annotations
+
+from collections.abc import Iterator, Sequence
 
 from surinort_ast.core.nodes import ASTNode
+
+from .selectors import create_selector
 
 # ============================================================================
 # Module Status - EXPERIMENTAL/ALPHA
@@ -433,7 +440,7 @@ def query_exists(node: ASTNode | Sequence[ASTNode], selector: str) -> bool:
 
 
 # ============================================================================
-# Classes (to be implemented)
+# Result wrapper and fluent builder
 # ============================================================================
 
 
@@ -441,71 +448,206 @@ class QueryResult:
     """
     Wrapper for query results with convenience methods.
 
-    Provides a fluent interface for working with query results,
-    including filtering, iteration, and common operations.
-
-    Attributes:
-        nodes: List of matched AST nodes
+    Provides a fluent interface for working with query results, including
+    counting, first/last access, existence checks, and further filtering.
 
     Example:
-        >>> result = QueryResult(query(rule, "Option"))
+        >>> result = QueryResult(query(rule, "ContentOption, SidOption"))
         >>> result.count()
-        5
-        >>> result.first()
-        <MsgOption>
+        2
+        >>> result.first() is not None
+        True
         >>> result.filter("SidOption").exists()
         True
-
-    Methods:
-        first()     - Get first result or None
-        last()      - Get last result or None
-        count()     - Count results
-        exists()    - Check if any results
-        filter()    - Further filter results
-        __iter__()  - Iterate over results
-        __len__()   - Get count
-        __getitem__() - Access by index
-
-    Note:
-        Phase 3 feature - not included in MVP
     """
 
-    # TODO: Implement in Phase 3
+    def __init__(self, nodes: Sequence[ASTNode], root: ASTNode | None = None) -> None:
+        """
+        Args:
+            nodes: Matched AST nodes.
+            root: Optional root the nodes were queried from (unused by the
+                current convenience methods; kept for future re-querying).
+        """
+        self._nodes: list[ASTNode] = list(nodes)
+        self._root = root
+
+    @property
+    def nodes(self) -> list[ASTNode]:
+        """Return a copy of the matched nodes."""
+        return list(self._nodes)
+
+    def first(self) -> ASTNode | None:
+        """Return the first matched node, or None."""
+        return self._nodes[0] if self._nodes else None
+
+    def last(self) -> ASTNode | None:
+        """Return the last matched node, or None."""
+        return self._nodes[-1] if self._nodes else None
+
+    def count(self) -> int:
+        """Return the number of matched nodes."""
+        return len(self._nodes)
+
+    def exists(self) -> bool:
+        """Return True if there is at least one matched node."""
+        return bool(self._nodes)
+
+    def filter(self, selector: str) -> QueryResult:
+        """
+        Narrow the result to nodes that themselves match a simple selector.
+
+        Args:
+            selector: A simple selector (type/attribute/compound/union, no
+                combinators) tested against each node directly.
+
+        Returns:
+            A new QueryResult with the surviving nodes.
+
+        Raises:
+            QuerySyntaxError: If the selector uses combinators.
+        """
+        return QueryResult(
+            [node for node in self._nodes if _node_matches_selector(node, selector)],
+            self._root,
+        )
+
+    def __iter__(self) -> Iterator[ASTNode]:
+        return iter(self._nodes)
+
+    def __len__(self) -> int:
+        return len(self._nodes)
+
+    def __getitem__(self, index: int) -> ASTNode:
+        return self._nodes[index]
+
+    def __repr__(self) -> str:
+        return f"QueryResult({len(self._nodes)} nodes)"
+
+
+# Friendly operator aliases accepted by Q.with_attr, mapped to grammar operators.
+_ATTR_OPERATORS = {
+    "equals": "=",
+    "eq": "=",
+    "not_equals": "!=",
+    "ne": "!=",
+    "gt": ">",
+    "lt": "<",
+    "gte": ">=",
+    "lte": "<=",
+    "contains": "*=",
+    "startswith": "^=",
+    "endswith": "$=",
+}
+
+
+def _format_attr_value(value: object) -> str:
+    """Format a Python value as a selector attribute value (STRING/NUMBER/IDENT)."""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int | float):
+        return str(value)
+    text = str(value)
+    if "'" not in text:
+        return f"'{text}'"
+    if '"' not in text:
+        return f'"{text}"'
+    return "'" + text.replace("'", "") + "'"
+
+
+def _node_matches_selector(node: ASTNode, selector: str) -> bool:
+    """Test a single node against a simple (combinator-free) selector string."""
+    from .parser import QueryParser
+
+    chain = QueryParser().parse(selector)
+    if getattr(chain, "combinators", None):
+        raise QuerySyntaxError(
+            "QueryResult.filter() supports only simple selectors (no combinators)"
+        )
+    sel = chain.selectors[0]
+    try:
+        return bool(sel.matches(node))
+    except TypeError:
+        # Pseudo-selectors require an execution context, which a standalone
+        # node test cannot provide.
+        return bool(sel.matches(node, None))
 
 
 class Q:
     """
-    Fluent query builder for programmatic query construction.
+    Fluent query builder for programmatic selector construction.
 
-    Provides a Python API for building queries without string manipulation.
-    Useful for dynamic query construction and IDE autocompletion.
+    Builds a selector string without manual string manipulation; the result of
+    :meth:`build` round-trips through :func:`query`.
 
     Example:
-        >>> # Build query programmatically
-        >>> query_obj = (
+        >>> selector = (
         ...     Q("Rule")
         ...     .with_attr("action", "alert")
-        ...     .descendant(Q("ContentOption").with_attr("pattern", "*admin*", "contains"))
+        ...     .descendant(Q("ContentOption"))
+        ...     .build()
         ... )
-        >>> selector_string = query_obj.build()
-        >>> results = query(rule, selector_string)
-        >>>
-        >>> # Equivalent to: "Rule[action=alert] ContentOption[pattern*='admin']"
-
-    Methods:
-        with_attr()     - Add attribute filter
-        descendant()    - Add descendant combinator
-        child()         - Add child combinator
-        adjacent()      - Add adjacent sibling
-        sibling()       - Add general sibling
-        or_()           - Add union (OR)
-        build()         - Build selector string
-
-    Note:
-        Phase 3 feature - not included in MVP
+        >>> selector
+        "Rule[action='alert'] ContentOption"
     """
 
-    # TODO: Implement in Phase 3
+    def __init__(self, type_name: str | None = None) -> None:
+        """
+        Args:
+            type_name: Optional initial type selector (e.g. "Rule"). Omit for
+                a universal-style start built up purely from attributes.
+        """
+        self._selector = "" if type_name is None else str(type_name)
+
+    def with_attr(self, name: str, value: object = None, operator: str = "=") -> Q:
+        """
+        Append an attribute filter ``[name op value]`` (or ``[name]`` for existence).
+
+        Args:
+            name: Attribute name.
+            value: Value to compare; omit for an existence check.
+            operator: Grammar operator ("=", "!=", ">", ...) or a friendly
+                alias ("equals", "contains", "startswith", ...).
+        """
+        op = _ATTR_OPERATORS.get(operator, operator)
+        if value is None:
+            self._selector += f"[{name}]"
+        else:
+            self._selector += f"[{name}{op}{_format_attr_value(value)}]"
+        return self
+
+    def descendant(self, other: Q | str) -> Q:
+        """Append a descendant combinator (space) followed by ``other``."""
+        return self._combine(" ", other)
+
+    def child(self, other: Q | str) -> Q:
+        """Append a child combinator (>) followed by ``other``."""
+        return self._combine(" > ", other)
+
+    def adjacent(self, other: Q | str) -> Q:
+        """Append an adjacent-sibling combinator (+) followed by ``other``."""
+        return self._combine(" + ", other)
+
+    def sibling(self, other: Q | str) -> Q:
+        """Append a general-sibling combinator (~) followed by ``other``."""
+        return self._combine(" ~ ", other)
+
+    def or_(self, other: Q | str) -> Q:
+        """Append a union (comma) followed by ``other``."""
+        return self._combine(", ", other)
+
+    def _combine(self, combinator: str, other: Q | str) -> Q:
+        self._selector += f"{combinator}{other.build() if isinstance(other, Q) else other}"
+        return self
+
+    def build(self) -> str:
+        """Return the assembled selector string."""
+        return self._selector
+
+    def __str__(self) -> str:
+        return self._selector
+
+    def __repr__(self) -> str:
+        return f"Q({self._selector!r})"
 
 
 # ============================================================================
@@ -581,13 +723,11 @@ class InvalidSelectorError(QueryError):
 __all__ = [
     "InvalidSelectorError",
     "Q",
-    # Exceptions
     "QueryError",
     "QueryExecutionError",
-    # Classes (Phase 3)
     "QueryResult",
     "QuerySyntaxError",
-    # Core query functions
+    "create_selector",
     "query",
     "query_all",
     "query_exists",

--- a/src/surinort_ast/query/executor.py
+++ b/src/surinort_ast/query/executor.py
@@ -11,7 +11,7 @@ Author: Marc Rivero López | @seifreed | mriverolopez@gmail.com
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 
 # Import only what's needed at module level to avoid circular dependency
 # Combinator enum and other selector classes imported locally where used
@@ -411,55 +411,105 @@ class QueryExecutor(ASTVisitor[list[ASTNode]]):
 
 
 # ============================================================================
-# Optimized Executors (Phase 3)
+# Optimized Executors
 # ============================================================================
 
 
 class IndexedQueryExecutor(QueryExecutor):
     """
-    Query executor with pre-computed indices for fast lookups.
+    Query executor with a pre-computed node-type index for fast lookups.
 
-    Builds type and attribute indices during initialization for
-    O(1) lookups instead of O(n) traversals. Useful for repeated
-    queries on large corpora.
-
-    Attributes:
-        type_index: Dict mapping node types to lists of nodes
-        attribute_indices: Dict of attribute-specific indices
+    Builds a ``node_type -> [nodes]`` index over the root once, so that a query
+    consisting of a single exact :class:`TypeSelector` is answered by an index
+    lookup instead of a full traversal. Repeated queries against the same root
+    reuse the index. All other queries (attributes, combinators, subclass
+    matching, unions) delegate to the base traversal so results are identical.
 
     Example:
-        >>> # Build indices for 30K rules
-        >>> executor = IndexedQueryExecutor.build(rules)
-        >>>
-        >>> # Fast type lookup
-        >>> results = executor.execute(chain)  # Uses index, not traversal
-
-    Implementation:
-        Phase 3 (optional): For performance-critical use cases
-        Trade-off: Memory usage vs. query speed
+        >>> executor = IndexedQueryExecutor(chain).index(rules)
+        >>> results = executor.execute(rules)
     """
 
-    # TODO: Implement in Phase 3 (post-MVP)
+    def __init__(self, selector_chain: Any) -> None:
+        super().__init__(selector_chain)
+        self._indexed_root_id: int | None = None
+        self._type_index: dict[str, list[ASTNode]] = {}
+
+    def index(self, root: ASTNode | Sequence[ASTNode]) -> IndexedQueryExecutor:
+        """Pre-build the index for ``root`` and return self for chaining."""
+        self._build_index(root)
+        return self
+
+    def _build_index(self, root: ASTNode | Sequence[ASTNode]) -> None:
+        self._type_index = {}
+        nodes = root if isinstance(root, Sequence) else [root]
+        for node in nodes:
+            self._index_node(node)
+        self._indexed_root_id = id(root)
+
+    def _index_node(self, node: ASTNode) -> None:
+        # Pre-order, mirroring the base traversal so result order is identical.
+        self._type_index.setdefault(node.node_type, []).append(node)
+        for child in self._get_children(node):
+            self._index_node(child)
+
+    def execute(self, root: ASTNode | Sequence[ASTNode]) -> list[ASTNode]:
+        type_name = self._indexable_type()
+        if type_name is None:
+            return super().execute(root)
+        if self._indexed_root_id != id(root):
+            self._build_index(root)
+        return list(self._type_index.get(type_name, []))
+
+    def _indexable_type(self) -> str | None:
+        """Return the type name if this query is a single exact TypeSelector."""
+        from .selectors import TypeSelector
+
+        if self.is_union:
+            return None
+        selectors = self.selector_chain.selectors
+        if len(selectors) != 1:
+            return None
+        selector = selectors[0]
+        if not isinstance(selector, TypeSelector) or selector.match_subclasses:
+            return None
+        return selector.type_name
 
 
 class StreamingQueryExecutor(QueryExecutor):
     """
-    Query executor for streaming/incremental results.
+    Query executor that yields results incrementally.
 
-    Yields results as they are found instead of accumulating them.
-    Useful for large result sets or when processing can start before
-    query completes.
+    For a single, non-pseudo selector the matching nodes are yielded as they are
+    encountered during traversal, so a consumer can start processing before the
+    whole tree is walked. Combinator chains, unions, and pseudo-selectors need
+    full execution context and fall back to eager evaluation, yielding from the
+    completed result list.
 
     Example:
         >>> executor = StreamingQueryExecutor(chain)
-        >>> for node in executor.execute_stream(rules):
+        >>> for node in executor.execute_stream(rule):
         ...     process(node)  # Process incrementally
-
-    Implementation:
-        Phase 3 (optional): For memory-constrained environments
     """
 
-    # TODO: Implement in Phase 3 (post-MVP)
+    def execute_stream(self, root: ASTNode | Sequence[ASTNode]) -> Iterator[ASTNode]:
+        """Yield matching nodes, incrementally where possible."""
+        from .selectors import PseudoSelector
+
+        selectors = None if self.is_union else self.selector_chain.selectors
+        if selectors and len(selectors) == 1 and not isinstance(selectors[0], PseudoSelector):
+            selector = selectors[0]
+            nodes = root if isinstance(root, Sequence) else [root]
+            for node in nodes:
+                yield from self._stream_node(node, selector)
+        else:
+            yield from self.execute(root)
+
+    def _stream_node(self, node: ASTNode, selector: Any) -> Iterator[ASTNode]:
+        if selector.matches(node):
+            yield node
+        for child in self._get_children(node):
+            yield from self._stream_node(child, selector)
 
 
 # ============================================================================
@@ -606,47 +656,140 @@ class ExecutionContext:
 
 
 # ============================================================================
-# Performance Utilities (Phase 3)
+# Performance Utilities
 # ============================================================================
 
 
-def estimate_query_cost(selector_chain: Any) -> int:  # SelectorChain type
-    """
-    Estimate computational cost of query.
+# Relative cost weights used by estimate_query_cost (higher = more expensive).
+_COMPARISON_OPERATORS = frozenset({">", "<", ">=", "<="})
+_STRING_OPERATORS = frozenset({"*=", "^=", "$="})
+_COMBINATOR_WEIGHTS = {" ": 3, ">": 1, "+": 1, "~": 2}
+# Selectivity rank for fail-fast ordering (lower = more selective, evaluated first).
+_SELECTIVITY_RANK = {"type": 0, "attribute_eq": 1, "attribute_cmp": 2, "pseudo": 3, "universal": 4}
 
-    Returns cost estimate for query execution, useful for
-    optimization decisions.
+
+def _selector_cost(selector: Any) -> int:
+    from .selectors import (
+        AttributeSelector,
+        CompoundSelector,
+        PseudoSelector,
+        TypeSelector,
+        UniversalSelector,
+    )
+
+    if isinstance(selector, TypeSelector):
+        return 2 if selector.match_subclasses else 1
+    if isinstance(selector, UniversalSelector):
+        return 5
+    if isinstance(selector, AttributeSelector):
+        if selector.operator in _STRING_OPERATORS:
+            return 4
+        if selector.operator in _COMPARISON_OPERATORS:
+            return 3
+        return 2
+    if isinstance(selector, PseudoSelector):
+        return 5
+    if isinstance(selector, CompoundSelector):
+        return sum(_selector_cost(inner) for inner in selector.selectors)
+    return 1
+
+
+def estimate_query_cost(selector_chain: Any) -> int:
+    """
+    Estimate the relative computational cost of executing a query.
+
+    The estimate is a heuristic: each selector contributes a base cost (cheap
+    exact type matches up to expensive string/pseudo matches), scaled by the
+    weight of the combinator that follows it (a descendant combinator walks the
+    whole subtree and so costs more than a child/adjacent combinator). Higher
+    means more expensive. Useful for comparing alternative formulations of the
+    same query.
 
     Args:
-        selector_chain: Selector chain to estimate
+        selector_chain: A SelectorChain or UnionSelector.
 
     Returns:
-        Cost estimate (higher = more expensive)
-
-    Implementation:
-        Phase 3: Heuristic-based cost model
+        A non-negative cost estimate.
     """
-    # TODO: Implement in Phase 3
-    return 0
+    from .parser import SelectorChain
+    from .selectors import UnionSelector
+
+    if isinstance(selector_chain, UnionSelector):
+        return sum(estimate_query_cost(sub) for sub in selector_chain.selectors)
+    if not isinstance(selector_chain, SelectorChain):
+        return 0
+
+    total = 0
+    combinators = selector_chain.combinators
+    for index, selector in enumerate(selector_chain.selectors):
+        cost = _selector_cost(selector)
+        if index < len(combinators):
+            cost *= _COMBINATOR_WEIGHTS.get(_combinator_symbol(combinators[index]), 1)
+        total += cost
+    return total
 
 
-def optimize_selector_chain(selector_chain: Any) -> Any:  # SelectorChain type
+def _combinator_symbol(combinator: Any) -> str:
+    return getattr(combinator, "value", str(combinator))
+
+
+def _selectivity_key(selector: Any) -> int:
+    from .selectors import (
+        AttributeSelector,
+        PseudoSelector,
+        TypeSelector,
+        UniversalSelector,
+    )
+
+    if isinstance(selector, TypeSelector):
+        return _SELECTIVITY_RANK["type"]
+    if isinstance(selector, AttributeSelector):
+        if selector.operator == "=":
+            return _SELECTIVITY_RANK["attribute_eq"]
+        return _SELECTIVITY_RANK["attribute_cmp"]
+    if isinstance(selector, PseudoSelector):
+        return _SELECTIVITY_RANK["pseudo"]
+    if isinstance(selector, UniversalSelector):
+        return _SELECTIVITY_RANK["universal"]
+    return _SELECTIVITY_RANK["attribute_cmp"]
+
+
+def _optimize_compound(selector: Any) -> Any:
+    """Reorder a compound selector fail-fast first and drop duplicates (AND commutes)."""
+    from .selectors import CompoundSelector
+
+    if not isinstance(selector, CompoundSelector):
+        return selector
+    unique: list[Any] = []
+    for inner in selector.selectors:
+        if inner not in unique:
+            unique.append(inner)
+    unique.sort(key=_selectivity_key)
+    return CompoundSelector(unique)
+
+
+def optimize_selector_chain(selector_chain: Any) -> Any:
     """
-    Optimize selector chain for faster execution.
+    Rewrite a selector chain for cheaper execution, preserving its result set.
 
-    Applies optimizations like:
-        - Reordering compound selectors (fail-fast first)
-        - Combining adjacent type selectors
-        - Simplifying redundant conditions
+    Only semantics-preserving transformations are applied: within each compound
+    selector (a logical AND, which commutes) the most selective sub-selectors
+    are evaluated first and exact duplicates are removed. The order of selectors
+    across combinators is never changed.
 
     Args:
-        selector_chain: Original selector chain
+        selector_chain: A SelectorChain or UnionSelector.
 
     Returns:
-        Optimized selector chain
-
-    Implementation:
-        Phase 3: Query optimization pass
+        An equivalent, optimized selector chain.
     """
-    # TODO: Implement in Phase 3
-    return selector_chain
+    from .parser import SelectorChain
+    from .selectors import UnionSelector
+
+    if isinstance(selector_chain, UnionSelector):
+        return UnionSelector([optimize_selector_chain(sub) for sub in selector_chain.selectors])
+    if not isinstance(selector_chain, SelectorChain):
+        return selector_chain
+
+    optimized = [_optimize_compound(selector) for selector in selector_chain.selectors]
+    return SelectorChain(optimized, list(selector_chain.combinators))

--- a/src/surinort_ast/query/parser.py
+++ b/src/surinort_ast/query/parser.py
@@ -14,6 +14,8 @@ from typing import Any
 
 from lark import Lark, Token, Transformer
 
+from .selectors import UnionSelector
+
 # ============================================================================
 # Parser Implementation (Phase 1)
 # ============================================================================
@@ -487,22 +489,24 @@ class SelectorTransformer(Transformer[Any, Any]):
 # ============================================================================
 
 
-def validate_selector_chain(chain: SelectorChain) -> None:
+def validate_selector_chain(chain: SelectorChain | UnionSelector) -> None:
     """
     Validate semantic correctness of selector chain.
+
+    A union query (``A, B``) transforms to a :class:`UnionSelector`; each of its
+    sub-chains is validated individually.
 
     Checks for:
         - Empty selector chains
         - Mismatched combinator/selector counts
 
     Args:
-        chain: Parsed selector chain
+        chain: Parsed selector chain or union of chains.
 
     Raises:
         InvalidSelectorError: If chain has semantic errors
     """
     from . import InvalidSelectorError
-    from .selectors import UnionSelector
 
     # UnionSelector wraps multiple chains; validate each sub-chain individually
     if isinstance(chain, UnionSelector):

--- a/src/surinort_ast/query/registry.py
+++ b/src/surinort_ast/query/registry.py
@@ -1,0 +1,43 @@
+"""
+Runtime registry mapping AST node type names to their classes.
+
+The query engine identifies nodes by ``node.node_type`` (the class name).
+For subclass-aware matching and indexed execution it also needs to resolve a
+type name back to its Python class so that ``isinstance`` checks can include
+derived types. This module builds that mapping once by introspecting the
+``ASTNode`` class hierarchy defined in :mod:`surinort_ast.core.nodes`, so it
+never drifts from the node definitions.
+
+Licensed under GNU General Public License v3.0
+Author: Marc Rivero | @seifreed | mriverolopez@gmail.com
+"""
+
+from __future__ import annotations
+
+from ..core.nodes import ASTNode
+
+
+def _build_registry() -> dict[str, type[ASTNode]]:
+    """Walk the ASTNode subclass tree and map class name -> class."""
+    registry: dict[str, type[ASTNode]] = {}
+    stack: list[type[ASTNode]] = [ASTNode]
+    seen: set[type[ASTNode]] = set()
+    while stack:
+        cls = stack.pop()
+        if cls in seen:
+            continue
+        seen.add(cls)
+        registry[cls.__name__] = cls
+        stack.extend(cls.__subclasses__())
+    return registry
+
+
+NODE_TYPE_REGISTRY: dict[str, type[ASTNode]] = _build_registry()
+
+
+def resolve_node_type(name: str) -> type[ASTNode] | None:
+    """Return the AST node class for ``name``, or None if it is unknown."""
+    return NODE_TYPE_REGISTRY.get(name)
+
+
+__all__ = ["NODE_TYPE_REGISTRY", "resolve_node_type"]

--- a/src/surinort_ast/query/selectors.py
+++ b/src/surinort_ast/query/selectors.py
@@ -15,6 +15,8 @@ from typing import TYPE_CHECKING, Any
 
 from surinort_ast.core.nodes import ASTNode
 
+from .registry import resolve_node_type
+
 # Avoid circular imports - ExecutionContext, QueryExecutor, SelectorChain
 # are imported locally where needed
 if TYPE_CHECKING:
@@ -104,10 +106,6 @@ class TypeSelector(Selector):
         >>> selector = TypeSelector("AddressExpr", match_subclasses=True)
         >>> selector.matches(IPAddress(value="192.168.1.1", version=4))
         True
-
-    Implementation:
-        Phase 1: Exact type matching only
-        Phase 2: Subclass matching with isinstance()
     """
 
     def __init__(self, type_name: str, match_subclasses: bool = False) -> None:
@@ -125,20 +123,23 @@ class TypeSelector(Selector):
         """
         Test if node type matches.
 
+        With ``match_subclasses`` the node matches the named type or any of
+        its AST subclasses (e.g. ``TypeSelector("Option", match_subclasses=True)``
+        matches ``SidOption``, ``MsgOption``, ...). Otherwise the match is on the
+        exact ``node_type`` name.
+
         Args:
             node: AST node to test
 
         Returns:
             True if node type matches
-
-        Implementation:
-            Phase 1: Simple string comparison with node.node_type
-            Phase 2: Add isinstance() check for subclass matching
         """
-        # Phase 1: Simple exact type matching
         if self.match_subclasses:
-            # Phase 2 feature - not implemented yet
-            raise NotImplementedError("Subclass matching not yet implemented")
+            target = resolve_node_type(self.type_name)
+            if target is not None:
+                return isinstance(node, target)
+            # Unknown type name: fall back to exact-name matching.
+            return node.node_type == self.type_name
         return node.node_type == self.type_name
 
     def __repr__(self) -> str:
@@ -795,9 +796,36 @@ class Combinator(Enum):
 # ============================================================================
 
 
+_VALID_PSEUDO_TYPES = frozenset(
+    {
+        "first",
+        "first-child",
+        "last",
+        "last-child",
+        "empty",
+        "not-empty",
+        "even",
+        "odd",
+        "has",
+        "not",
+        "within",
+        "nth",
+    }
+)
+
+
 def create_selector(selector_type: str, **kwargs: Any) -> Selector:
     """
-    Factory function for creating selectors.
+    Factory for creating selectors from a type string and keyword arguments.
+
+    Supported ``selector_type`` values and their required kwargs:
+
+    - ``"type"``: ``type_name`` (optional ``match_subclasses``)
+    - ``"universal"``: none
+    - ``"attribute"``: ``attribute``, ``operator`` (optional ``value``)
+    - ``"compound"``: ``selectors``
+    - ``"union"``: ``selectors``
+    - ``"pseudo"``: ``pseudo_type`` (optional ``argument``)
 
     Args:
         selector_type: Type of selector to create
@@ -807,15 +835,41 @@ def create_selector(selector_type: str, **kwargs: Any) -> Selector:
         Selector instance
 
     Raises:
-        InvalidSelectorError: If selector_type is unknown
+        InvalidSelectorError: If ``selector_type`` is unknown, required
+            arguments are missing, or an argument is invalid.
 
     Example:
         >>> selector = create_selector("type", type_name="Rule")
-        >>> selector = create_selector("attribute", attribute="value", operator="=", value=1)
-
-    Implementation:
-        Phase 1: Basic factory for type and attribute selectors
-        Phase 3: Complete factory for all selector types
+        >>> selector = create_selector("attribute", attribute="value", operator=">", value=1)
     """
-    # TODO: Implement in Phase 1
-    raise NotImplementedError("create_selector not yet implemented")
+    from . import InvalidSelectorError
+
+    def _require(*names: str) -> None:
+        missing = [name for name in names if name not in kwargs]
+        if missing:
+            raise InvalidSelectorError(
+                f"create_selector({selector_type!r}) requires: {', '.join(missing)}"
+            )
+
+    if selector_type == "type":
+        _require("type_name")
+        return TypeSelector(kwargs["type_name"], kwargs.get("match_subclasses", False))
+    if selector_type == "universal":
+        return UniversalSelector()
+    if selector_type == "attribute":
+        _require("attribute", "operator")
+        return AttributeSelector(kwargs["attribute"], kwargs["operator"], kwargs.get("value"))
+    if selector_type == "compound":
+        _require("selectors")
+        return CompoundSelector(kwargs["selectors"])
+    if selector_type == "union":
+        _require("selectors")
+        return UnionSelector(kwargs["selectors"])
+    if selector_type == "pseudo":
+        _require("pseudo_type")
+        pseudo_type = kwargs["pseudo_type"]
+        if pseudo_type not in _VALID_PSEUDO_TYPES:
+            raise InvalidSelectorError(f"Invalid pseudo-selector type: {pseudo_type}")
+        return PseudoSelector(pseudo_type, kwargs.get("argument"))
+
+    raise InvalidSelectorError(f"Unknown selector type: {selector_type}")

--- a/tests/unit/test_query_builders.py
+++ b/tests/unit/test_query_builders.py
@@ -1,0 +1,201 @@
+"""Tests for the query selector factory, subclass matching, QueryResult, and Q builder."""
+
+from __future__ import annotations
+
+import pytest
+
+from surinort_ast import parse_rule
+from surinort_ast.query import (
+    InvalidSelectorError,
+    Q,
+    QueryResult,
+    QuerySyntaxError,
+    create_selector,
+    query,
+)
+from surinort_ast.query.selectors import (
+    AttributeSelector,
+    CompoundSelector,
+    PseudoSelector,
+    TypeSelector,
+    UnionSelector,
+    UniversalSelector,
+)
+
+RULE_TEXT = 'alert tcp any any -> any 80 (msg:"t"; content:"admin"; sid:1000001; rev:1;)'
+
+
+@pytest.fixture
+def rule():
+    return parse_rule(RULE_TEXT)
+
+
+class TestCreateSelector:
+    def test_type(self):
+        sel = create_selector("type", type_name="Rule")
+        assert isinstance(sel, TypeSelector)
+        assert sel.type_name == "Rule"
+        assert sel.match_subclasses is False
+
+    def test_type_with_subclasses(self):
+        sel = create_selector("type", type_name="Option", match_subclasses=True)
+        assert isinstance(sel, TypeSelector)
+        assert sel.match_subclasses is True
+
+    def test_universal(self):
+        assert isinstance(create_selector("universal"), UniversalSelector)
+
+    def test_attribute(self):
+        sel = create_selector("attribute", attribute="value", operator=">", value=1)
+        assert isinstance(sel, AttributeSelector)
+        assert sel.attribute == "value"
+        assert sel.operator == ">"
+        assert sel.value == 1
+
+    def test_compound(self):
+        inner = [TypeSelector("Rule"), AttributeSelector("action", "=", "alert")]
+        sel = create_selector("compound", selectors=inner)
+        assert isinstance(sel, CompoundSelector)
+
+    def test_union(self):
+        inner = [TypeSelector("ContentOption"), TypeSelector("PcreOption")]
+        assert isinstance(create_selector("union", selectors=inner), UnionSelector)
+
+    def test_pseudo(self):
+        assert isinstance(create_selector("pseudo", pseudo_type="first"), PseudoSelector)
+
+    def test_unknown_type_raises(self):
+        with pytest.raises(InvalidSelectorError):
+            create_selector("bogus")
+
+    def test_missing_required_kwargs_raises(self):
+        with pytest.raises(InvalidSelectorError):
+            create_selector("type")
+        with pytest.raises(InvalidSelectorError):
+            create_selector("attribute", attribute="value")  # missing operator
+        with pytest.raises(InvalidSelectorError):
+            create_selector("pseudo")
+
+    def test_invalid_pseudo_type_raises(self):
+        with pytest.raises(InvalidSelectorError):
+            create_selector("pseudo", pseudo_type="not-a-pseudo")
+
+    def test_invalid_operator_raises(self):
+        with pytest.raises(InvalidSelectorError):
+            create_selector("attribute", attribute="value", operator="~~")
+
+
+class TestSubclassMatching:
+    def test_exact_does_not_match_base(self, rule):
+        sid = query(rule, "SidOption")[0]
+        assert TypeSelector("Option").matches(sid) is False
+
+    def test_subclass_matches_base(self, rule):
+        sid = query(rule, "SidOption")[0]
+        assert TypeSelector("Option", match_subclasses=True).matches(sid) is True
+
+    def test_subclass_address_hierarchy(self, rule):
+        # Header src_addr is an AddressExpr subclass (AnyAddress here)
+        addr = rule.header.src_addr
+        assert TypeSelector("AddressExpr", match_subclasses=True).matches(addr) is True
+        assert TypeSelector("AddressExpr").matches(addr) is False
+
+    def test_unknown_type_name_falls_back_to_exact(self, rule):
+        sid = query(rule, "SidOption")[0]
+        sel = TypeSelector("DefinitelyNotARealType", match_subclasses=True)
+        assert sel.matches(sid) is False
+
+    def test_subclass_flag_in_equality_and_hash(self):
+        a = TypeSelector("Option", match_subclasses=True)
+        b = TypeSelector("Option", match_subclasses=True)
+        c = TypeSelector("Option", match_subclasses=False)
+        assert a == b
+        assert a != c
+        assert hash(a) == hash(b)
+
+
+class TestQueryResult:
+    def test_basic_accessors(self, rule):
+        res = QueryResult(query(rule, "ContentOption, SidOption"), root=rule)
+        assert res.count() == 2
+        assert len(res) == 2
+        assert res.exists() is True
+        assert res.first().node_type == "ContentOption"
+        assert res.last().node_type == "SidOption"
+        assert res[0].node_type == "ContentOption"
+        assert [n.node_type for n in res] == ["ContentOption", "SidOption"]
+        assert len(res.nodes) == 2
+
+    def test_empty(self):
+        res = QueryResult([])
+        assert res.count() == 0
+        assert res.exists() is False
+        assert res.first() is None
+        assert res.last() is None
+
+    def test_filter_narrows(self, rule):
+        res = QueryResult(query(rule, "ContentOption, SidOption"), root=rule)
+        filtered = res.filter("SidOption")
+        assert filtered.count() == 1
+        assert filtered.first().node_type == "SidOption"
+
+    def test_filter_attribute(self, rule):
+        res = QueryResult(query(rule, "SidOption"), root=rule)
+        assert res.filter("SidOption[value=1000001]").exists() is True
+        assert res.filter("SidOption[value=999]").exists() is False
+
+    def test_filter_rejects_combinators(self, rule):
+        res = QueryResult(query(rule, "SidOption"))
+        with pytest.raises(QuerySyntaxError):
+            res.filter("Rule > Header")
+
+    def test_repr(self):
+        assert "2 nodes" in repr(QueryResult([object(), object()]))  # type: ignore[list-item]
+
+
+class TestQBuilder:
+    def test_simple_type(self):
+        assert Q("Rule").build() == "Rule"
+
+    def test_with_attr_equals(self):
+        assert Q("Rule").with_attr("action", "alert").build() == "Rule[action='alert']"
+
+    def test_with_attr_numeric(self):
+        assert Q("SidOption").with_attr("value", 1000, "gt").build() == "SidOption[value>1000]"
+
+    def test_with_attr_existence(self):
+        assert Q("ContentOption").with_attr("modifiers").build() == "ContentOption[modifiers]"
+
+    def test_operator_aliases(self):
+        assert Q("M").with_attr("text", "x", "contains").build() == "M[text*='x']"
+        assert Q("M").with_attr("text", "x", "startswith").build() == "M[text^='x']"
+        assert Q("M").with_attr("text", "x", "endswith").build() == "M[text$='x']"
+
+    def test_combinators(self):
+        assert Q("Rule").descendant(Q("ContentOption")).build() == "Rule ContentOption"
+        assert Q("Rule").child(Q("Header")).build() == "Rule > Header"
+        assert Q("A").adjacent(Q("B")).build() == "A + B"
+        assert Q("A").sibling(Q("B")).build() == "A ~ B"
+        assert Q("A").or_(Q("B")).build() == "A, B"
+
+    def test_combinator_accepts_string(self):
+        assert Q("Rule").descendant("ContentOption").build() == "Rule ContentOption"
+
+    def test_str_and_repr(self):
+        q = Q("Rule")
+        assert str(q) == "Rule"
+        assert repr(q) == "Q('Rule')"
+
+    def test_roundtrip_through_query(self, rule):
+        built = Q("ContentOption").build()
+        assert len(query(rule, built)) == len(query(rule, "ContentOption"))
+
+    def test_roundtrip_attribute_through_query(self, rule):
+        built = Q("SidOption").with_attr("value", 1000001).build()
+        results = query(rule, built)
+        assert len(results) == 1
+        assert results[0].node_type == "SidOption"
+
+    def test_roundtrip_descendant_through_query(self, rule):
+        built = Q("Rule").descendant(Q("ContentOption")).build()
+        assert len(query(rule, built)) == 1

--- a/tests/unit/test_query_complete.py
+++ b/tests/unit/test_query_complete.py
@@ -911,17 +911,17 @@ class TestSelectorChainValidation:
             )
 
 
-class TestNotImplementedFeatures:
-    """Test that Phase 2/3 features properly raise NotImplementedError."""
+class TestSelectorBehavior:
+    """Behavioural tests for selector matching."""
 
-    def test_type_selector_subclass_matching_not_implemented(self):
-        """Test subclass matching raises NotImplementedError."""
+    def test_type_selector_subclass_matching(self):
+        """Subclass matching matches a base type against its derived types."""
         selector = TypeSelector("Option", match_subclasses=True)
         rule = parse_rule("alert tcp any any -> any 80 (sid:1;)")
         sid_node = query_first(rule, "SidOption")
 
-        with pytest.raises(NotImplementedError):
-            selector.matches(sid_node)
+        assert selector.matches(sid_node) is True
+        assert TypeSelector("Option").matches(sid_node) is False
 
     def test_attribute_selector_comparison_operators_work(self):
         """Test comparison operators work correctly."""
@@ -956,13 +956,9 @@ class TestNotImplementedFeatures:
         selector_lte_fail = AttributeSelector("value", "<=", 1000000)
         assert selector_lte_fail.matches(sid_node) is False
 
-    def test_multi_selector_chain_not_implemented(self):
-        """Test multi-selector chains raise NotImplementedError."""
+    def test_single_selector_chain_parses(self):
+        """A bare type selector parses to a chain with one selector."""
         parser = QueryParser()
-
-        # Phase 2 feature - descendant combinator with whitespace
-        # This will parse but the executor doesn't support it yet
-        # For now, just test that parsing a complex chain works
         chain = parser.parse("Rule")
         assert len(chain.selectors) == 1
 

--- a/tests/unit/test_query_exec.py
+++ b/tests/unit/test_query_exec.py
@@ -1,0 +1,157 @@
+"""Tests for indexed/streaming executors and the query cost/optimization utilities."""
+
+from __future__ import annotations
+
+import pytest
+
+from surinort_ast import parse_rule
+from surinort_ast.query.executor import (
+    IndexedQueryExecutor,
+    QueryExecutor,
+    StreamingQueryExecutor,
+    estimate_query_cost,
+    optimize_selector_chain,
+)
+from surinort_ast.query.parser import QueryParser
+
+RULE = 'alert tcp 1.2.3.4 any -> any 80 (msg:"t"; content:"a"; content:"b"; sid:1000001; rev:1;)'
+
+SELECTORS = [
+    "ContentOption",
+    "Option",
+    "SidOption",
+    "SidOption[value>1]",
+    "Rule",
+    "Header",
+    "Rule > Header",
+    "Rule ContentOption",
+    "ContentOption, SidOption",
+    "*",
+]
+
+
+@pytest.fixture
+def rule():
+    return parse_rule(RULE)
+
+
+@pytest.fixture
+def parser():
+    return QueryParser()
+
+
+class TestIndexedQueryExecutor:
+    @pytest.mark.parametrize("selector", SELECTORS)
+    def test_identical_to_base(self, rule, parser, selector):
+        chain = parser.parse(selector)
+        base = QueryExecutor(chain).execute(rule)
+        indexed = IndexedQueryExecutor(parser.parse(selector)).execute(rule)
+        assert indexed == base
+
+    def test_index_method_returns_self(self, rule, parser):
+        ex = IndexedQueryExecutor(parser.parse("ContentOption"))
+        assert ex.index(rule) is ex
+
+    def test_index_reused_across_calls(self, rule, parser):
+        ex = IndexedQueryExecutor(parser.parse("ContentOption")).index(rule)
+        first = ex.execute(rule)
+        second = ex.execute(rule)
+        assert first == second == QueryExecutor(parser.parse("ContentOption")).execute(rule)
+
+    def test_subclass_query_delegates_and_matches(self, rule, parser):
+        # match_subclasses can't use the exact-type index; must still be correct
+        from surinort_ast.query.selectors import TypeSelector
+
+        chain_cls = parser.parse("Option")  # exact -> 0 results
+        assert IndexedQueryExecutor(chain_cls).execute(rule) == []
+        # build a subclass-matching chain manually
+        sub_chain = parser.parse("SidOption")
+        sub_chain.selectors[0] = TypeSelector("Option", match_subclasses=True)
+        indexed = IndexedQueryExecutor(sub_chain).execute(rule)
+        base = QueryExecutor(sub_chain).execute(rule)
+        assert indexed == base
+        assert len(indexed) > 0
+
+
+class TestStreamingQueryExecutor:
+    @pytest.mark.parametrize("selector", SELECTORS)
+    def test_identical_to_base(self, rule, parser, selector):
+        base = QueryExecutor(parser.parse(selector)).execute(rule)
+        streamed = list(StreamingQueryExecutor(parser.parse(selector)).execute_stream(rule))
+        assert streamed == base
+
+    def test_returns_iterator(self, rule, parser):
+        stream = StreamingQueryExecutor(parser.parse("ContentOption")).execute_stream(rule)
+        assert iter(stream) is stream  # generator is its own iterator
+        assert len(list(stream)) == 2
+
+    def test_lazy_first_match(self, rule, parser):
+        stream = StreamingQueryExecutor(parser.parse("ContentOption")).execute_stream(rule)
+        first = next(stream)
+        assert first.node_type == "ContentOption"
+
+
+class TestEstimateQueryCost:
+    def test_zero_for_non_chain(self):
+        assert estimate_query_cost(object()) == 0
+
+    def test_adding_selector_increases_cost(self, parser):
+        c1 = estimate_query_cost(parser.parse("ContentOption"))
+        c2 = estimate_query_cost(parser.parse("Rule ContentOption"))
+        assert c2 > c1
+
+    def test_descendant_costs_more_than_child(self, parser):
+        descendant = estimate_query_cost(parser.parse("Rule ContentOption"))
+        child = estimate_query_cost(parser.parse("Rule > ContentOption"))
+        assert descendant > child
+
+    def test_string_operator_costs_more_than_equality(self, parser):
+        eq = estimate_query_cost(parser.parse("MsgOption[text=x]"))
+        contains = estimate_query_cost(parser.parse("MsgOption[text*='x']"))
+        assert contains > eq
+
+    def test_union_sums_subchains(self, parser):
+        single = estimate_query_cost(parser.parse("ContentOption"))
+        union = estimate_query_cost(parser.parse("ContentOption, SidOption"))
+        assert union >= single
+
+
+class TestOptimizeSelectorChain:
+    @pytest.mark.parametrize(
+        "selector",
+        [
+            "Rule[action=alert]",
+            "SidOption[value>1]",
+            "Rule ContentOption",
+            "Rule > Header[protocol=tcp]",
+            "ContentOption, SidOption",
+        ],
+    )
+    def test_preserves_result_set(self, rule, parser, selector):
+        original = QueryExecutor(parser.parse(selector)).execute(rule)
+        optimized = QueryExecutor(optimize_selector_chain(parser.parse(selector))).execute(rule)
+        assert optimized == original
+
+    def test_non_chain_passthrough(self):
+        sentinel = object()
+        assert optimize_selector_chain(sentinel) is sentinel
+
+    def test_compound_dedup_and_reorder(self, parser):
+        # A compound with a universal + a type: type is more selective and should come first.
+        from surinort_ast.query.parser import SelectorChain
+        from surinort_ast.query.selectors import (
+            CompoundSelector,
+            TypeSelector,
+            UniversalSelector,
+        )
+
+        compound = CompoundSelector(
+            [UniversalSelector(), TypeSelector("Rule"), TypeSelector("Rule")]
+        )
+        chain = SelectorChain([compound], [])
+        optimized = optimize_selector_chain(chain)
+        inner = optimized.selectors[0].selectors
+        # duplicate TypeSelector removed (3 -> 2) and TypeSelector ordered before UniversalSelector
+        assert len(inner) == 2
+        assert isinstance(inner[0], TypeSelector)
+        assert isinstance(inner[1], UniversalSelector)


### PR DESCRIPTION
Phase 2 of implementing the pending `query/` stubs (builds on #107).

## Implemented (`query/executor.py`)
- **`IndexedQueryExecutor`** — builds a `node_type → [nodes]` index (pre-order, matching base result order); answers single exact-`TypeSelector` queries by lookup, reused across calls via `.index(root)`. Everything else delegates to the base executor ⇒ identical results.
- **`StreamingQueryExecutor.execute_stream`** — generator yielding matches incrementally for a single non-pseudo selector; eager fallback for combinator/union/pseudo chains.
- **`estimate_query_cost`** — heuristic (per-selector base cost × following-combinator weight; descendant > child/adjacent); sums union sub-chains; 0 for non-chains.
- **`optimize_selector_chain`** — semantics-preserving: within each compound (AND commutes) removes duplicates and orders most-selective first; never reorders across combinators.

## Verification
- `ruff`, `ruff format --check`, `mypy --strict` — clean.
- `tests/unit/test_query_exec.py` — 37 tests asserting result-equivalence with the base executor across 10 selector shapes, cost monotonicity/ordering, and result-set preservation under optimization. Full non-slow suite: **1806 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)