### PR TITLE
feat(validation): streaming SID-uniqueness + validate_rule rev check

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,0 +1,16 @@
+# CodeGraph data files
+# These are local to each machine and should not be committed
+
+# Database
+*.db
+*.db-wal
+*.db-shm
+
+# Cache
+cache/
+
+# Logs
+*.log
+
+# Hook markers
+.dirty

--- a/.cursor/rules/codegraph.mdc
+++ b/.cursor/rules/codegraph.mdc
@@ -1,0 +1,39 @@
+---
+description: CodeGraph MCP usage guide — when to use which tool
+alwaysApply: true
+---
+<!-- CODEGRAPH_START -->
+## CodeGraph
+
+This project has a CodeGraph MCP server (`codegraph_*` tools) configured. CodeGraph is a tree-sitter-parsed knowledge graph of every symbol, edge, and file. Reads are sub-millisecond and return structural information grep cannot.
+
+### When to prefer codegraph over native search
+
+Use codegraph for **structural** questions — what calls what, what would break, where is X defined, what is X's signature. Use native grep/read only for **literal text** queries (string contents, comments, log messages) or after you already have a specific file open.
+
+| Question | Tool |
+|---|---|
+| "Where is X defined?" / "Find symbol named X" | `codegraph_search` |
+| "What calls function Y?" | `codegraph_callers` |
+| "What does Y call?" | `codegraph_callees` |
+| "How does X reach/become Y? / trace the flow from X to Y" | `codegraph_trace` (one call = the whole path, incl. callback/React/JSX dynamic hops) |
+| "What would break if I changed Z?" | `codegraph_impact` |
+| "Show me Y's signature / source / docstring" | `codegraph_node` |
+| "Give me focused context for a task/area" | `codegraph_context` |
+| "See several related symbols' source at once" | `codegraph_explore` |
+| "What files exist under path/" | `codegraph_files` |
+| "Is the index healthy?" | `codegraph_status` |
+
+### Rules of thumb
+
+- **Answer directly — don't delegate exploration.** For "how does X work" / architecture questions, answer with 2-3 codegraph calls: `codegraph_context` first, then ONE `codegraph_explore` for the source of the symbols it surfaces. For a specific **flow** ("how does X reach Y") start with `codegraph_trace` from→to — one call returns the whole path with dynamic hops bridged — then ONE `codegraph_explore` for the bodies; don't rebuild the path with `codegraph_search` + `codegraph_callers`. Codegraph IS the pre-built index, so spawning a separate file-reading sub-task/agent — or running a grep + read loop — repeats work codegraph already did and costs more for the same answer.
+- **Trust codegraph results.** They come from a full AST parse. Do NOT re-verify them with grep — that's slower, less accurate, and wastes context.
+- **Don't grep first** when looking up a symbol by name. `codegraph_search` is faster and returns kind + location + signature in one call.
+- **Don't chain `codegraph_search` + `codegraph_node`** when you just want context — `codegraph_context` is one call.
+- **Don't loop `codegraph_node` over many symbols** — one `codegraph_explore` call returns several symbols' source grouped in a single capped call, while each separate node/Read call re-reads the whole context and costs far more.
+- **Index lag**: the file watcher debounces ~500ms behind writes; don't re-query immediately after editing a file in the same turn.
+
+### If `.codegraph/` doesn't exist
+
+The MCP server returns "not initialized." Ask the user: *"I notice this project doesn't have CodeGraph initialized. Want me to run `codegraph init -i` to build the index?"*
+<!-- CODEGRAPH_END -->

--- a/src/surinort_ast/api/validation.py
+++ b/src/surinort_ast/api/validation.py
@@ -33,9 +33,10 @@ def validate_rule(rule: Rule) -> list[Diagnostic]:
     """
     diagnostics: list[Diagnostic] = []
 
-    # Check for required options
+    # Check for recommended options
     has_sid = any(opt.node_type == "SidOption" for opt in rule.options)
     has_msg = any(opt.node_type == "MsgOption" for opt in rule.options)
+    has_rev = any(opt.node_type == "RevOption" for opt in rule.options)
 
     if not has_sid:
         diagnostics.append(
@@ -55,10 +56,18 @@ def validate_rule(rule: Rule) -> list[Diagnostic]:
             )
         )
 
-    # Check for duplicate SIDs (would need multiple rules context)
-    # Check for deprecated options based on dialect
-    # Check for conflicting options
-    # etc.
+    if has_sid and not has_rev:
+        diagnostics.append(
+            Diagnostic(
+                level=DiagnosticLevel.INFO,
+                message="Missing recommended option 'rev'",
+                code="missing_rev",
+            )
+        )
+
+    # Cross-rule checks (duplicate SIDs, shadowing, conflicting actions) require a
+    # whole rule set and live in surinort_ast.analysis.conflicts and the streaming
+    # ValidateProcessor, not in this single-rule validator.
 
     # Include any diagnostics from parsing
     if rule.diagnostics:

--- a/src/surinort_ast/streaming/processor.py
+++ b/src/surinort_ast/streaming/processor.py
@@ -302,6 +302,7 @@ class ValidateProcessor(StreamProcessor):
         """
         self.strict = strict
         self.custom_validators = custom_validators or []
+        self._seen_sids: set[int] = set()
 
     def process(self, rule: Rule) -> Rule | None:
         """
@@ -349,17 +350,35 @@ class ValidateProcessor(StreamProcessor):
 
     def _validate_sid_uniqueness(self, rule: Rule) -> list[Diagnostic]:
         """
-        Validate SID uniqueness (placeholder for multi-rule context).
+        Flag a rule whose SID was already seen earlier in the stream.
+
+        Uniqueness is tracked statefully across the rules this processor has
+        handled. Use :meth:`reset` to clear the tracked SIDs before reusing the
+        processor on a new stream.
 
         Args:
             rule: Rule to validate
 
         Returns:
-            List of diagnostics
+            A single duplicate-SID warning if the SID repeats, else an empty list.
         """
-        # Note: True SID uniqueness requires tracking across multiple rules
-        # This is a placeholder for single-rule validation
+        for option in rule.options:
+            if isinstance(option, SidOption):
+                if option.value in self._seen_sids:
+                    return [
+                        Diagnostic(
+                            level=DiagnosticLevel.WARNING,
+                            message=f"Duplicate SID {option.value}",
+                            code="duplicate_sid",
+                        )
+                    ]
+                self._seen_sids.add(option.value)
+                break
         return []
+
+    def reset(self) -> None:
+        """Clear the SIDs tracked for uniqueness checks."""
+        self._seen_sids.clear()
 
 
 # ============================================================================

--- a/tests/unit/test_validation_stubs.py
+++ b/tests/unit/test_validation_stubs.py
@@ -1,0 +1,55 @@
+"""Tests for streaming SID-uniqueness validation and validate_rule's rev check."""
+
+from __future__ import annotations
+
+from surinort_ast import parse_rule
+from surinort_ast.api.validation import validate_rule
+from surinort_ast.streaming.processor import ValidateProcessor
+
+
+def _codes(rule):
+    return {d.code for d in rule.diagnostics}
+
+
+class TestSidUniquenessStreaming:
+    def test_duplicate_sid_flagged_across_stream(self):
+        processor = ValidateProcessor()
+        first = processor.process(
+            parse_rule('alert tcp any any -> any 80 (msg:"A"; sid:1; rev:1;)')
+        )
+        second = processor.process(
+            parse_rule('alert udp any any -> any 53 (msg:"B"; sid:1; rev:1;)')
+        )
+        assert "duplicate_sid" not in _codes(first)
+        assert "duplicate_sid" in _codes(second)
+
+    def test_unique_sids_not_flagged(self):
+        processor = ValidateProcessor()
+        r1 = processor.process(parse_rule('alert tcp any any -> any 80 (msg:"A"; sid:1; rev:1;)'))
+        r2 = processor.process(parse_rule('alert tcp any any -> any 80 (msg:"B"; sid:2; rev:1;)'))
+        assert "duplicate_sid" not in _codes(r1)
+        assert "duplicate_sid" not in _codes(r2)
+
+    def test_reset_clears_seen_sids(self):
+        processor = ValidateProcessor()
+        processor.process(parse_rule('alert tcp any any -> any 80 (msg:"A"; sid:1; rev:1;)'))
+        processor.reset()
+        again = processor.process(
+            parse_rule('alert tcp any any -> any 80 (msg:"A"; sid:1; rev:1;)')
+        )
+        assert "duplicate_sid" not in _codes(again)
+
+
+class TestValidateRuleRev:
+    def test_missing_rev_info_when_sid_present(self):
+        diags = validate_rule(parse_rule('alert tcp any any -> any 80 (msg:"t"; sid:1;)'))
+        assert any(d.code == "missing_rev" for d in diags)
+
+    def test_no_missing_rev_when_rev_present(self):
+        diags = validate_rule(parse_rule('alert tcp any any -> any 80 (msg:"t"; sid:1; rev:2;)'))
+        assert not any(d.code == "missing_rev" for d in diags)
+
+    def test_no_missing_rev_when_no_sid(self):
+        # Without a sid the rev recommendation does not apply (sid is the primary gap).
+        diags = validate_rule(parse_rule('alert tcp any any -> any 80 (msg:"t"; content:"a";)'))
+        assert not any(d.code == "missing_rev" for d in diags)


### PR DESCRIPTION
Phase 4 (final) of the implement-the-stubs effort — the small remaining placeholders.

## Implemented
- **`ValidateProcessor._validate_sid_uniqueness`** (was a placeholder returning `[]`): now tracks SIDs seen across the stream and emits a `duplicate_sid` warning on repeats; `reset()` clears the tracked set for reuse.
- **`validate_rule`**: emits an INFO `missing_rev` diagnostic when a rule has a `sid` but no `rev` (parallel to the existing `missing_sid`/`missing_msg` checks). The speculative "duplicate SID / deprecated / conflicting options" comment is replaced with a note pointing cross-rule checks to `analysis.conflicts` and the streaming `ValidateProcessor`.

## Not done (intentional)
The remaining skipped tests exercise the **deprecated `RuleParser`** (slated for removal) — not stubs to implement; the grammar-path skip is a legitimate environment-conditional skip.

## Verification
- `ruff`, `ruff format --check`, `mypy --strict` — clean.
- `tests/unit/test_validation_stubs.py` — 6 new tests. Full non-slow suite green (no diagnostic-count regressions from the new INFO).

🤖 Generated with [Claude Code](https://claude.com/claude-code)