### PR TITLE
feat: enforce catalogued engine features

### DIFF
--- a/docs/api-compatibility.md
+++ b/docs/api-compatibility.md
@@ -56,6 +56,10 @@ unsupported AST majors.
   complete output from the installed engine before treating unknown keywords
   as errors. `EngineTarget.from_keyword_listing()` accepts plain or tabular
   `--list-keywords` output and marks the resulting keyword catalog complete.
+  Feature requirements such as `sticky-buffer`, `flowbits`, `byte-ops`, and
+  `pcre` use the same tri-state behavior through `with_features()` and
+  `feature_catalog_complete`; only a complete feature catalog produces an
+  unsupported-feature error.
 - `RulesetContext.from_suricata_yaml()` and `from_snort_config()` resolve
   deployment variables for coverage analysis; unresolved variables remain
   indeterminate instead of being reported as uncovered concrete ports.

--- a/docs/api-compatibility.md
+++ b/docs/api-compatibility.md
@@ -59,7 +59,7 @@ unsupported AST majors.
   Feature requirements such as `sticky-buffer`, `flowbits`, `byte-ops`, and
   `pcre` use the same tri-state behavior through `with_features()` and
   `feature_catalog_complete`; only a complete feature catalog produces an
-  unsupported-feature error.
+  `unsupported_engine_feature` error.
 - `RulesetContext.from_suricata_yaml()` and `from_snort_config()` resolve
   deployment variables for coverage analysis; unresolved variables remain
   indeterminate instead of being reported as uncovered concrete ports.

--- a/src/surinort_ast/analysis/targets.py
+++ b/src/surinort_ast/analysis/targets.py
@@ -19,6 +19,7 @@ class EngineTarget:
     aliases: tuple[tuple[str, str], ...] = ()
     deprecated_keywords: frozenset[str] = frozenset()
     keyword_catalog_complete: bool = False
+    feature_catalog_complete: bool = False
 
     def supports(self, keyword: str) -> bool | None:
         """Return true/false when known, or ``None`` when not catalogued."""
@@ -39,6 +40,12 @@ class EngineTarget:
             _normalize(item) for item in self.deprecated_keywords
         }
 
+    def supports_feature(self, feature: str) -> bool | None:
+        """Return feature support when the target publishes a feature catalog."""
+        if not self.feature_catalog_complete:
+            return None
+        return _normalize(feature) in {_normalize(item) for item in self.features}
+
     def supports_action(self, action: str) -> bool | None:
         """Return action support when the target publishes an action list."""
         return _supports(self.actions, action)
@@ -53,6 +60,14 @@ class EngineTarget:
             self,
             keywords=frozenset(keywords),
             keyword_catalog_complete=True,
+        )
+
+    def with_features(self, features: set[str] | frozenset[str]) -> EngineTarget:
+        """Return a target populated from a complete feature listing."""
+        return replace(
+            self,
+            features=frozenset(features),
+            feature_catalog_complete=True,
         )
 
     @classmethod
@@ -144,11 +159,30 @@ def default_capability_registry() -> CapabilityRegistry:
             "sid",
         }
     )
+    common_features = frozenset({"byte-ops", "flowbits", "pcre"})
     return CapabilityRegistry(
         (
-            EngineTarget("suricata", "8.x", common, frozenset({"app-layer", "sticky-buffer"})),
-            EngineTarget("snort", "2.x", common, frozenset()),
-            EngineTarget("snort", "3.x", common, frozenset({"sticky-buffer"})),
+            EngineTarget(
+                "suricata",
+                "8.x",
+                common,
+                common_features | frozenset({"app-layer", "sticky-buffer"}),
+                feature_catalog_complete=True,
+            ),
+            EngineTarget(
+                "snort",
+                "2.x",
+                common,
+                common_features,
+                feature_catalog_complete=True,
+            ),
+            EngineTarget(
+                "snort",
+                "3.x",
+                common,
+                common_features | frozenset({"sticky-buffer"}),
+                feature_catalog_complete=True,
+            ),
         )
     )
 

--- a/src/surinort_ast/api/validation.py
+++ b/src/surinort_ast/api/validation.py
@@ -523,6 +523,21 @@ def _validate_relative_patterns(rule: Rule) -> list[Diagnostic]:
     diagnostics: list[Diagnostic] = []
     has_anchor = False
     for option in rule.options:
+        flags = {str(flag).lower() for flag in getattr(option, "flags", ())}
+        if (
+            option.node_type in {"ByteTestOption", "ByteJumpOption", "ByteExtractOption"}
+            and "relative" in flags
+            and not has_anchor
+        ):
+            diagnostics.append(
+                Diagnostic(
+                    level=DiagnosticLevel.ERROR,
+                    message="Relative byte operation requires a preceding content or byte match",
+                    location=option.location,
+                    code="relative_byte_operation_without_anchor",
+                    phase="option-chain",
+                )
+            )
         if option.node_type in {"ContentOption", "ByteTestOption", "ByteJumpOption"}:
             has_anchor = True
         if option.node_type == "PcreOption" and "r" in str(getattr(option, "flags", "")).lower():

--- a/src/surinort_ast/api/validation.py
+++ b/src/surinort_ast/api/validation.py
@@ -68,6 +68,14 @@ _BYTE_TEST_OPERATORS = {
     ">=",
     "^",
 }
+_OPTION_FEATURES = {
+    "BufferSelectOption": "sticky-buffer",
+    "FlowbitsOption": "flowbits",
+    "ByteTestOption": "byte-ops",
+    "ByteJumpOption": "byte-ops",
+    "ByteExtractOption": "byte-ops",
+    "PcreOption": "pcre",
+}
 _FLOWBIT_ACTIONS = {"set", "isset", "isnotset", "toggle", "unset", "noalert"}
 _FLOWBIT_NAME_REQUIRED = {"set", "isset", "isnotset", "toggle", "unset"}
 
@@ -226,6 +234,18 @@ def _validate_target_options(rule: Rule, target: EngineTarget) -> list[Diagnosti
     for option in rule.options:
         keyword = _option_keyword(option)
         support = target.supports(keyword)
+        feature = _OPTION_FEATURES.get(option.node_type)
+        if feature is not None and target.supports_feature(feature) is False:
+            diagnostics.append(
+                Diagnostic(
+                    level=DiagnosticLevel.ERROR,
+                    message=f"Feature '{feature}' is not listed for {target.engine} {target.version}",
+                    location=option.location,
+                    code="unsupported_engine_feature",
+                    hint="Use a compatible engine target or remove the dependent option.",
+                    phase="version",
+                )
+            )
         if option.node_type == "BufferSelectOption":
             buffer_name = str(getattr(option, "buffer_name", "")).lower()
             buffer_support = target.supports(buffer_name)

--- a/tests/unit/test_engine_targets.py
+++ b/tests/unit/test_engine_targets.py
@@ -18,6 +18,14 @@ def test_engine_keyword_listing_can_populate_target() -> None:
     assert target.keyword_catalog_complete is True
 
 
+def test_engine_feature_listing_is_tri_state() -> None:
+    target = EngineTarget("suricata", "8.x").with_features({"sticky-buffer"})
+
+    assert target.supports_feature("sticky-buffer") is True
+    assert target.supports_feature("byte-ops") is False
+    assert EngineTarget("suricata", "8.x").supports_feature("sticky-buffer") is None
+
+
 def test_engine_keyword_listing_parser_handles_headers_and_descriptions() -> None:
     listing = """
     Keyword                 Description

--- a/tests/unit/test_semantic_validation.py
+++ b/tests/unit/test_semantic_validation.py
@@ -82,6 +82,15 @@ def test_sticky_buffer_and_protocol_constraints_are_reported() -> None:
 def test_relative_and_byte_operator_constraints_are_reported() -> None:
     found = codes('alert tcp any any -> any 80 (pcre:"/x/R"; sid:1;)')
     assert "relative_pcre_without_anchor" in found
+    assert "relative_byte_operation_without_anchor" in codes(
+        "alert tcp any any -> any 80 (byte_test:1,>,1,0,relative; sid:1;)"
+    )
+    assert "relative_byte_operation_without_anchor" in codes(
+        "alert tcp any any -> any 80 (byte_extract:1,0,value,relative; sid:1;)"
+    )
+    assert "relative_byte_operation_without_anchor" not in codes(
+        'alert tcp any any -> any 80 (content:"x"; byte_jump:1,0,relative; sid:1;)'
+    )
     assert "relative_modifier_without_content" in codes(
         'alert tcp any any -> any 80 (content:"x",within 5; sid:1;)'
     )

--- a/tests/unit/test_semantic_validation.py
+++ b/tests/unit/test_semantic_validation.py
@@ -130,3 +130,28 @@ def test_engine_target_accepts_catalogued_sticky_buffer_name() -> None:
     found = {diagnostic.code for diagnostic in validate_rule(rule, target=target)}
 
     assert "unsupported_engine_keyword" not in found
+
+
+def test_engine_target_rejects_options_with_missing_catalogued_features() -> None:
+    target = EngineTarget(
+        "snort",
+        "2.9.x",
+        keywords=frozenset({"buffer_select", "flowbits", "byte_test", "sid"}),
+        features=frozenset({"byte-ops", "flowbits", "pcre"}),
+        feature_catalog_complete=True,
+        keyword_catalog_complete=True,
+    )
+
+    sticky = parse_rule('alert tcp any any -> any 80 (http_uri; content:"x"; sid:1;)')
+    byte_rule = parse_rule("alert tcp any any -> any 80 (byte_test:1,>,1,0; sid:1;)")
+    flowbit_rule = parse_rule("alert tcp any any -> any 80 (flowbits:set,seen; sid:1;)")
+
+    assert "unsupported_engine_feature" in {
+        diagnostic.code for diagnostic in validate_rule(sticky, target=target)
+    }
+    assert "unsupported_engine_feature" not in {
+        diagnostic.code for diagnostic in validate_rule(byte_rule, target=target)
+    }
+    assert "unsupported_engine_feature" not in {
+        diagnostic.code for diagnostic in validate_rule(flowbit_rule, target=target)
+    }

--- a/tests/unit/test_semantic_validation.py
+++ b/tests/unit/test_semantic_validation.py
@@ -136,7 +136,7 @@ def test_engine_target_rejects_options_with_missing_catalogued_features() -> Non
     target = EngineTarget(
         "snort",
         "2.9.x",
-        keywords=frozenset({"buffer_select", "flowbits", "byte_test", "sid"}),
+        keywords=frozenset({"buffer_select", "content", "flowbits", "byte_test", "sid"}),
         features=frozenset({"byte-ops", "flowbits", "pcre"}),
         feature_catalog_complete=True,
         keyword_catalog_complete=True,


### PR DESCRIPTION
Enforces feature requirements when an EngineTarget has a complete feature catalog. Adds tri-state feature APIs, default common engine features, semantic diagnostics, tests, and compatibility documentation.