### PR TITLE
fix: preserve feature catalog evidence from listings

### DIFF
--- a/src/surinort_ast/analysis/targets.py
+++ b/src/surinort_ast/analysis/targets.py
@@ -77,7 +77,7 @@ class EngineTarget:
         version: str,
         listing: str,
         *,
-        features: frozenset[str] = frozenset(),
+        features: frozenset[str] | None = None,
         actions: frozenset[str] = frozenset(),
         protocols: frozenset[str] = frozenset(),
     ) -> EngineTarget:
@@ -90,10 +90,11 @@ class EngineTarget:
             engine=engine,
             version=version,
             keywords=parse_keyword_listing(listing),
-            features=features,
+            features=frozenset(features) if features is not None else frozenset(),
             actions=actions,
             protocols=protocols,
             keyword_catalog_complete=True,
+            feature_catalog_complete=features is not None,
         )
 
 

--- a/tests/unit/test_engine_targets.py
+++ b/tests/unit/test_engine_targets.py
@@ -41,6 +41,24 @@ def test_engine_keyword_listing_parser_handles_headers_and_descriptions() -> Non
     assert target.supports("missing") is False
 
 
+def test_engine_keyword_listing_marks_supplied_features_complete() -> None:
+    target = EngineTarget.from_keyword_listing(
+        "suricata",
+        "8.0.0",
+        "content\npcre\n",
+        features=frozenset({"pcre"}),
+    )
+
+    assert target.supports_feature("pcre") is True
+    assert target.supports_feature("sticky-buffer") is False
+
+
+def test_engine_keyword_listing_without_features_keeps_features_unknown() -> None:
+    target = EngineTarget.from_keyword_listing("suricata", "8.0.0", "content\n")
+
+    assert target.supports_feature("pcre") is None
+
+
 def test_target_models_aliases_deprecations_and_domains() -> None:
     target = EngineTarget(
         "suricata",


### PR DESCRIPTION
## Summary\n- mark supplied feature listings complete in EngineTarget.from_keyword_listing\n- keep omitted feature listings tri-state unknown\n- add regression coverage for both paths\n\n## Verification\n- pytest -q tests/unit/test_engine_targets.py tests/unit/test_semantic_validation.py\n- ruff check\n- mypy src/surinort_ast/analysis/targets.py