### PR TITLE
fix: validate engine matrix inputs before execution

### DIFF
--- a/tests/unit/test_conformance_lab.py
+++ b/tests/unit/test_conformance_lab.py
@@ -2,6 +2,7 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
 from tools.conformance_lab import run
 from tools.engine_matrix import load_matrix, run_matrix
 
@@ -70,6 +71,68 @@ def test_engine_matrix_runs_declared_entries(tmp_path) -> None:
     assert report["total_rules"] == 1
     assert report["unexpected_failures"] == 0
     assert report["engines"][0]["report"]["engine_validation_passed"] == 1
+
+
+def test_engine_matrix_rejects_invalid_dialect_and_missing_manifest(tmp_path) -> None:
+    matrix = tmp_path / "matrix.json"
+    matrix.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "engines": [
+                    {
+                        "id": "invalid-dialect",
+                        "engine": "suricata",
+                        "version": "8.0.0",
+                        "dialect": "unknown",
+                        "manifest": "missing.json",
+                        "command": "engine -S {file}",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="dialect"):
+        load_matrix(matrix)
+
+    payload = json.loads(matrix.read_text(encoding="utf-8"))
+    payload["engines"][0]["dialect"] = "suricata"
+    matrix.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="manifest does not exist"):
+        load_matrix(matrix)
+
+
+def test_engine_matrix_requires_matching_pcap_placeholder(tmp_path) -> None:
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text('{"files": []}', encoding="utf-8")
+    pcap = tmp_path / "traffic.pcap"
+    pcap.write_bytes(b"pcap")
+    matrix = tmp_path / "matrix.json"
+    matrix.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "engines": [
+                    {
+                        "id": "missing-pcap-placeholder",
+                        "engine": "suricata",
+                        "version": "8.0.0",
+                        "dialect": "suricata",
+                        "manifest": "manifest.json",
+                        "pcap": "traffic.pcap",
+                        "command": "engine -S {file}",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="must contain \\{pcap\\}"):
+        load_matrix(matrix)
 
 
 def test_conformance_engine_checks_original_and_printed_rule(tmp_path) -> None:

--- a/tools/engine_matrix.py
+++ b/tools/engine_matrix.py
@@ -26,6 +26,21 @@ class MatrixEntry:
     pcap: Path | None = None
 
 
+def _resolve_pcap(path: Path, entry_id: str, value: object, command: str) -> Path | None:
+    if value is None or value == "":
+        if "{pcap}" in command:
+            raise ValueError(f"engine matrix command for {entry_id} requires a pcap path")
+        return None
+    if not isinstance(value, str):
+        raise ValueError(f"engine matrix pcap for {entry_id} must be a string")
+    pcap_path = (path.parent / value).resolve()
+    if not pcap_path.is_file():
+        raise ValueError(f"engine matrix pcap does not exist for {entry_id}: {pcap_path}")
+    if "{pcap}" not in command:
+        raise ValueError(f"engine matrix command for {entry_id} must contain {{pcap}}")
+    return pcap_path
+
+
 def load_matrix(path: Path) -> list[MatrixEntry]:
     """Load and validate a versioned engine matrix."""
     payload = json.loads(path.read_text(encoding="utf-8"))
@@ -36,26 +51,36 @@ def load_matrix(path: Path) -> list[MatrixEntry]:
         raise ValueError("engine matrix must contain a non-empty 'engines' list")
 
     loaded: list[MatrixEntry] = []
+    seen_ids: set[str] = set()
     for entry in entries:
         if not isinstance(entry, dict):
             raise ValueError("each engine matrix entry must be an object")
         required = ("id", "engine", "version", "dialect", "manifest", "command")
         if any(not isinstance(entry.get(key), str) or not entry[key] for key in required):
             raise ValueError(f"engine matrix entries require string fields: {', '.join(required)}")
+        entry_id = entry["id"]
+        if entry_id in seen_ids:
+            raise ValueError(f"engine matrix entry id is duplicated: {entry_id}")
+        seen_ids.add(entry_id)
+        try:
+            dialect = Dialect(entry["dialect"])
+        except ValueError as exc:
+            raise ValueError(f"engine matrix dialect is invalid for {entry_id}") from exc
         if "{file}" not in entry["command"]:
-            raise ValueError(f"engine matrix command for {entry['id']} must contain {{file}}")
-        pcap = entry.get("pcap")
-        if pcap is not None and not isinstance(pcap, str):
-            raise ValueError(f"engine matrix pcap for {entry['id']} must be a string")
+            raise ValueError(f"engine matrix command for {entry_id} must contain {{file}}")
+        manifest = (path.parent / entry["manifest"]).resolve()
+        if not manifest.is_file():
+            raise ValueError(f"engine matrix manifest does not exist for {entry_id}: {manifest}")
+        pcap_path = _resolve_pcap(path, entry_id, entry.get("pcap"), entry["command"])
         loaded.append(
             MatrixEntry(
-                id=entry["id"],
+                id=entry_id,
                 engine=entry["engine"],
                 version=entry["version"],
-                dialect=entry["dialect"],
-                manifest=(path.parent / entry["manifest"]).resolve(),
+                dialect=dialect.value,
+                manifest=manifest,
                 command=entry["command"],
-                pcap=(path.parent / pcap).resolve() if pcap else None,
+                pcap=pcap_path,
             )
         )
     return loaded


### PR DESCRIPTION
## Summary\n- validate dialects, duplicate IDs, and manifest paths before running a matrix\n- require matching PCAP paths and command placeholders\n- add regression tests for invalid matrix contracts\n\n## Verification\n- pytest -q tests/unit/test_conformance_lab.py\n- ruff check and format check\n- git diff --check