### PR TITLE
fix: enforce Snort priority range

### DIFF
--- a/src/surinort_ast/api/validation.py
+++ b/src/surinort_ast/api/validation.py
@@ -76,6 +76,7 @@ _OPTION_FEATURES = {
     "ByteExtractOption": "byte-ops",
     "PcreOption": "pcre",
 }
+_SNORT_PRIORITY_MAX = 255
 _FLOWBIT_ACTIONS = {"set", "isset", "isnotset", "toggle", "unset", "noalert"}
 _FLOWBIT_NAME_REQUIRED = {"set", "isset", "isnotset", "toggle", "unset"}
 
@@ -206,6 +207,27 @@ def _validate_fast_pattern(option: object, has_content: bool) -> list[Diagnostic
     return diagnostics
 
 
+def _validate_target_priority(rule: Rule, target: EngineTarget) -> list[Diagnostic]:
+    if not target.engine.lower().startswith("snort"):
+        return []
+    diagnostics: list[Diagnostic] = []
+    for option in rule.options:
+        if option.node_type != "PriorityOption":
+            continue
+        priority = getattr(option, "value", None)
+        if isinstance(priority, int) and priority > _SNORT_PRIORITY_MAX:
+            diagnostics.append(
+                Diagnostic(
+                    level=DiagnosticLevel.ERROR,
+                    message=f"Priority {priority} is outside the Snort range 1-{_SNORT_PRIORITY_MAX}",
+                    location=option.location,
+                    code="engine_priority_out_of_range",
+                    phase="version",
+                )
+            )
+    return diagnostics
+
+
 def _validate_target_options(rule: Rule, target: EngineTarget) -> list[Diagnostic]:
     diagnostics: list[Diagnostic] = []
     if target.supports_action(rule.action.value) is False:
@@ -231,6 +253,7 @@ def _validate_target_options(rule: Rule, target: EngineTarget) -> list[Diagnosti
                 phase="version",
             )
         )
+    diagnostics.extend(_validate_target_priority(rule, target))
     for option in rule.options:
         keyword = _option_keyword(option)
         support = target.supports(keyword)

--- a/tests/unit/test_semantic_validation.py
+++ b/tests/unit/test_semantic_validation.py
@@ -164,3 +164,16 @@ def test_engine_target_rejects_options_with_missing_catalogued_features() -> Non
     assert "unsupported_engine_feature" not in {
         diagnostic.code for diagnostic in validate_rule(flowbit_rule, target=target)
     }
+
+
+def test_engine_target_applies_snort_priority_range_only() -> None:
+    rule = parse_rule("alert tcp any any -> any 80 (priority:256; sid:1;)")
+    snort = EngineTarget("snort", "2.9.x")
+    suricata = EngineTarget("suricata", "8.0.0")
+
+    assert "engine_priority_out_of_range" in {
+        diagnostic.code for diagnostic in validate_rule(rule, target=snort)
+    }
+    assert "engine_priority_out_of_range" not in {
+        diagnostic.code for diagnostic in validate_rule(rule, target=suricata)
+    }


### PR DESCRIPTION
## Summary\n- reject priority values above 255 for Snort targets\n- preserve Suricata's unbounded documented priority behavior\n- add target-specific regression coverage\n\n## Verification\n- pytest -q tests/unit/test_semantic_validation.py tests/unit/test_engine_targets.py\n- ruff check and format check\n- mypy src/surinort_ast/api/validation.py